### PR TITLE
Issue-6: use IEF for entity reference fields

### DIFF
--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/.travis-before-script.sh
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/.travis-before-script.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e $DRUPAL_TI_DEBUG
+
+# Ensure the right Drupal version is installed.
+# The first time this is run, it will install Drupal.
+# Note: This function is re-entrant.
+drupal_ti_ensure_drupal
+
+# Change to the Drupal directory
+cd "$DRUPAL_TI_DRUPAL_DIR"
+
+# Download and apply core patches here, if needed.

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/.travis.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/.travis.yml
@@ -1,0 +1,116 @@
+# @file
+# .travis.yml - Drupal for Travis CI Integration
+#
+# Template provided by https://github.com/LionsAd/drupal_ti.
+#
+# Based for simpletest upon:
+#   https://github.com/sonnym/travis-ci-drupal-module-example
+
+language: php
+
+sudo: false
+
+php:
+  - 5.6
+  - 7
+
+matrix:
+  fast_finish: true
+
+env:
+  global:
+    # add composer's global bin directory to the path
+    # see: https://github.com/drush-ops/drush#install---composer
+    - PATH="$PATH:$HOME/.composer/vendor/bin"
+
+    # Configuration variables.
+    - DRUPAL_TI_MODULE_NAME="inline_entity_form"
+    - DRUPAL_TI_SIMPLETEST_GROUP="inline_entity_form"
+
+    # Define runners and environment vars to include before and after the
+    # main runners / environment vars.
+    #- DRUPAL_TI_SCRIPT_DIR_BEFORE="./drupal_ti/before"
+    #- DRUPAL_TI_SCRIPT_DIR_AFTER="./drupal_ti/after"
+
+    # The environment to use, supported are: drupal-7, drupal-8
+    - DRUPAL_TI_ENVIRONMENT="drupal-8"
+
+    # The installation profile to use:
+    #- DRUPAL_TI_INSTALL_PROFILE="testing"
+
+    # Drupal specific variables.
+    - DRUPAL_TI_DB="drupal_travis_db"
+    - DRUPAL_TI_DB_URL="mysql://root:@127.0.0.1/drupal_travis_db"
+    # Note: Do not add a trailing slash here.
+    - DRUPAL_TI_WEBSERVER_URL="http://127.0.0.1"
+    - DRUPAL_TI_WEBSERVER_PORT="8080"
+
+    # Simpletest specific commandline arguments, the DRUPAL_TI_SIMPLETEST_GROUP is appended at the end.
+    - DRUPAL_TI_SIMPLETEST_ARGS="--verbose --color --concurrency 4 --url $DRUPAL_TI_WEBSERVER_URL:$DRUPAL_TI_WEBSERVER_PORT"
+
+    # === Behat specific variables.
+    # This is relative to $TRAVIS_BUILD_DIR
+    - DRUPAL_TI_BEHAT_DIR="./tests/behat"
+    # These arguments are passed to the bin/behat command.
+    - DRUPAL_TI_BEHAT_ARGS=""
+    # Specify the filename of the behat.yml with the $DRUPAL_TI_DRUPAL_DIR variables.
+    - DRUPAL_TI_BEHAT_YML="behat.yml.dist"
+    # This is used to setup Xvfb.
+    - DRUPAL_TI_BEHAT_SCREENSIZE_COLOR="1280x1024x16"
+    # The version of selenium that should be used.
+    - DRUPAL_TI_BEHAT_SELENIUM_VERSION="2.48.2"
+    # Set DRUPAL_TI_BEHAT_DRIVER to "selenium" to use "firefox" or "chrome" here.
+    - DRUPAL_TI_BEHAT_DRIVER="phantomjs"
+    - DRUPAL_TI_BEHAT_BROWSER="firefox"
+
+    # PHPUnit specific commandline arguments.
+    - DRUPAL_TI_PHPUNIT_ARGS=""
+    # Specifying the phpunit-core src/ directory is useful when e.g. a vendor/
+    # directory is present in the module directory, which phpunit would then
+    # try to find tests in. This option is relative to $TRAVIS_BUILD_DIR.
+    #- DRUPAL_TI_PHPUNIT_CORE_SRC_DIRECTORY="./tests/src"
+
+    # Code coverage via coveralls.io
+    - DRUPAL_TI_COVERAGE="satooshi/php-coveralls:0.6.*"
+    # This needs to match your .coveralls.yml file.
+    - DRUPAL_TI_COVERAGE_FILE="build/logs/clover.xml"
+
+    # Debug options
+    #- DRUPAL_TI_DEBUG="-x -v"
+    # Set to "all" to output all files, set to e.g. "xvfb selenium" or "selenium",
+    # etc. to only output those channels.
+    #- DRUPAL_TI_DEBUG_FILE_OUTPUT="selenium xvfb webserver"
+
+  matrix:
+    - DRUPAL_TI_RUNNERS="phpunit-core simpletest"
+    #- DRUPAL_TI_RUNNERS="phpunit"
+    #- DRUPAL_TI_RUNNERS="behat"
+    #- DRUPAL_TI_RUNNERS="phpunit simpletest behat"
+    # Use phpunit-core to test modules with phpunit with Drupal 8 core.
+    #- DRUPAL_TI_RUNNERS="phpunit-core"
+
+mysql:
+  database: drupal_travis_db
+  username: root
+  encoding: utf8
+
+before_install:
+  - composer self-update
+  - composer global require "lionsad/drupal_ti:1.*"
+  - drupal-ti before_install
+
+install:
+  - drupal-ti install
+
+before_script:
+  - drupal-ti --include ".travis-before-script.sh"
+  - drupal-ti before_script
+
+script:
+  - drupal-ti script
+
+after_script:
+  - drupal-ti after_script
+
+notifications:
+  email: false

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/LICENSE.txt
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/LICENSE.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/README
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/README
@@ -1,0 +1,40 @@
+Provides a widget for inline management (creation, modification, removal) of referenced entities.
+The primary use case is the parent -> children one (product display -> products, order -> line items, etc.),
+where the child entities are never managed outside the parent form.
+Existing entities can also be referenced.
+
+Supports commerce_product_reference, commerce_line_item_reference and entityreference fields.
+Requires integration code to be provided for each entity type that can be referenced.
+Supports the commerce_product (including Commerce AutoSKU integraton),
+commerce_line_item, node, taxonomy_term entity types out of the box.
+
+Getting started
+---------------
+Edit the reference field for which you want to use this module
+(for example, the Product field on a product display node, or the Line Items
+one on commerce_order) and select one of the "Inline entity form" widgets.
+
+Widgets
+-------
+Two widgets are provided:
+- "Inline entity form - Single value" - Shows the inline form in a fieldset
+on the parent entity form. No additional action buttons are added.
+This widget assumes that it is operating on a single-value required reference
+field with one selected bundle.
+
+- "Inline entity form - Multiple values" - Shows an advanced widget
+for inline management of entities.
+Has optimal UX when there's only one bundle selected (this is the
+"Product types that can be referenced" setting on product reference fields).
+
+Integrating with Inline Entity Form
+-----------------------------------
+An entity type can add support for this module by declaring the
+inline entity form controller class in its entity info:
+
+$entity_info['commerce_line_item']['inline_form'] = array(
+  'controller' => 'CommerceLineItemInlineEntityFormController',
+);
+
+The controller needs to extend EntityInlineEntityFormController and at least
+override entityForm() to provide a functioning entity form.

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/composer.json
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "drupal/inline_entity_form",
+  "description": "Provides a widget for inline management (creation, modification, removal) of referenced entities.",
+  "type": "drupal-module",
+  "license": "GPL-2.0+",
+  "minimum-stability": "dev",
+  "require": { }
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/config/schema/inline_entity_form.schema.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/config/schema/inline_entity_form.schema.yml
@@ -1,0 +1,53 @@
+# Schema for the Inline Entity Reference module display settings.
+
+field.widget.settings.inline_entity_form_simple:
+  type: mapping
+  label: 'Inline entity reference display format settings'
+  mapping:
+    form_mode:
+      type: string
+      label: "Form mode"
+    override_labels:
+      type: boolean
+      label: "Override labels"
+    label_singular:
+      type: string
+      label: "Label (singular)"
+    label_plural:
+      type: string
+      label: "Label (plural)"
+    allow_new:
+      type: boolean
+      label: "Allow new"
+    allow_existing:
+      type: boolean
+      label: "Allow existing"
+    match_operator:
+      type: string
+      label: "Match operator"
+
+field.widget.settings.inline_entity_form_complex:
+  type: mapping
+  label: 'Inline entity reference display format settings'
+  mapping:
+    form_mode:
+      type: string
+      label: "Form mode"
+    override_labels:
+      type: boolean
+      label: "Override labels"
+    label_singular:
+      type: string
+      label: "Label (singular)"
+    label_plural:
+      type: string
+      label: "Label (plural)"
+    allow_new:
+      type: boolean
+      label: "Allow new"
+    allow_existing:
+      type: boolean
+      label: "Allow existing"
+    match_operator:
+      type: string
+      label: "Match operator"

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/css/commerce-product.css
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/css/commerce-product.css
@@ -1,0 +1,11 @@
+
+.ief-product-attributes .fieldset-wrapper {
+  margin-top: 15px;
+}
+.ief-product-attributes .fieldset-wrapper > div {
+  margin-right: 20px;
+}
+
+.ief-product-details .field-type-commerce-price .form-item {
+  margin-right: 15px;
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/css/inline_entity_form.css
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/css/inline_entity_form.css
@@ -1,0 +1,38 @@
+.ief-cardinality-count {
+  text-align: right;
+  font-size: 0.9em;
+}
+
+.ief-tabledrag-header {
+  border-right: none;
+}
+
+.ief-sort-order-header {
+  border-left: none;
+}
+
+.ief-first-column-header {
+  border-left: none;
+}
+
+.ief-tabledrag-handle {
+  padding-right: 0;
+  width: 20px;
+}
+
+.ief-tabledrag-handle a.tabledrag-handle {
+  padding-right: .5em;
+}
+
+fieldset.ief-entity-fieldset {
+  margin: 0;
+}
+
+.ief-row-form > td {
+  padding: 0;
+}
+
+.ief-row-form .ief-form-row {
+  border-bottom: 10px solid #ccc;
+  padding: 20px;
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/css/inline_entity_form.seven.css
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/css/inline_entity_form.seven.css
@@ -1,0 +1,31 @@
+
+.ief-row-entity-form {
+  background-color: #D5E9F2 !important;
+}
+
+.field-widget-inline-entity-form fieldset.form-wrapper {
+  border: 0;
+}
+.ief-entity-fieldset, .ief-entity-fieldset fieldset {
+  background-color: transparent;
+}
+.ief-form > .fieldset-wrapper {
+  background: #f2f2f2;
+  border: 1px solid #ccc !important;
+}
+
+.ief-form > .fieldset-wrapper {
+  border: 1px solid #ccc !important;
+}
+
+.ief-entity-fieldset > legend span.fieldset-legend {
+  border-bottom: 1px solid #E4E4E4;
+  font-weight: 600;
+  margin-top: 10px;
+  padding: 3px 0;
+  width: 100%;
+}
+
+.ief-entity-fieldset > .fieldset-wrapper {
+  margin-top: 5px;
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/inline_entity_form.api.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/inline_entity_form.api.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the Inline Entity Form module.
+ */
+
+/**
+ * Perform alterations before an entity form is included in the IEF widget.
+ *
+ * @param $entity_form
+ *   Nested array of form elements that comprise the entity form.
+ * @param $form_state
+ *   The form state of the parent form.
+ */
+function hook_inline_entity_form_entity_form_alter(&$entity_form, &$form_state) {
+  if ($entity_form['#entity_type'] == 'commerce_line_item') {
+    $entity_form['quantity']['#description'] = t('New quantity description.');
+  }
+}
+
+/**
+ * Perform alterations before the reference form is included in the IEF widget.
+ *
+ * The reference form is used to add existing entities through an autocomplete
+ * field
+ *
+ * @param $reference_form
+ *   Nested array of form elements that comprise the reference form.
+ * @param $form_state
+ *   The form state of the parent form.
+ */
+function hook_inline_entity_form_reference_form_alter(&$reference_form, &$form_state) {
+  $reference_form['entity_id']['#description'] = t('New autocomplete description');
+}
+
+/**
+ * Alter the fields used to represent an entity in the IEF table.
+ *
+ * @param array $fields
+ *   The fields, keyed by field name.
+ * @param array $context
+ *   An array with the following keys:
+ *   - parent_entity_type: The type of the parent entity.
+ *   - parent_bundle: The bundle of the parent entity.
+ *   - field_name: The name of the reference field on which IEF is operating.
+ *   - entity_type: The type of the referenced entities.
+ *   - allowed_bundles: Bundles allowed on the reference field.
+ *
+ * @see \Drupal\inline_entity_form\InlineFormInterface::getTableFields()
+ */
+function hook_inline_entity_form_table_fields_alter(&$fields, $context) {
+  if ($context['entity_type'] == 'commerce_product_variation') {
+    $fields['field_category'] = [
+      'type' => 'field',
+      'label' => t('Category'),
+      'weight' => 101,
+    ];
+  }
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/inline_entity_form.info.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/inline_entity_form.info.yml
@@ -1,0 +1,13 @@
+name: Inline Entity Form
+description: "Provides a widget for inline management (creation, modification, removal) of referenced entities. "
+type: module
+package: Fields
+# core: 8.x
+test_dependencies:
+  - entity_reference_revisions
+
+# Information added by Drupal.org packaging script on 2016-04-20
+version: '8.x-1.0-alpha6'
+core: '8.x'
+project: 'inline_entity_form'
+datestamp: 1461165841

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/inline_entity_form.libraries.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/inline_entity_form.libraries.yml
@@ -1,0 +1,15 @@
+widget:
+  version: VERSION
+  js:
+    js/inline_entity_form.js: {}
+  dependencies:
+    - core/jquery
+    - core/jquery.once
+    - core/drupal
+    - core/drupalSettings
+
+commerce_product.base:
+  version: VERSION
+  css:
+    theme:
+      css/commerce-product.css: {}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/inline_entity_form.module
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/inline_entity_form.module
@@ -1,0 +1,453 @@
+<?php
+
+/**
+ * @file
+ * Provides a widget for inline management (creation, modification, removal) of
+ * referenced entities. The primary use case is the parent -> children one
+ * (for example, order -> line items), where the child entities are never
+ * managed outside the parent form.
+ */
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+use Drupal\inline_entity_form\ElementSubmit;
+use Drupal\inline_entity_form\WidgetSubmit;
+use Drupal\inline_entity_form\Form\EntityInlineForm;
+use Drupal\inline_entity_form\Plugin\Field\FieldWidget\InlineEntityFormComplex;
+
+/**
+ * Implements hook_entity_type_build().
+ */
+function inline_entity_form_entity_type_build(array &$entity_types) {
+  /** @var \Drupal\Core\Entity\EntityTypeInterface[] $entity_types */
+  if (isset($entity_types['node']) && !$entity_types['node']->getHandlerClass('inline_form')) {
+    $entity_types['node']->setHandlerClass('inline_form', '\Drupal\inline_entity_form\Form\NodeInlineForm');
+  }
+
+  foreach ($entity_types as &$entity_type) {
+    if (!$entity_type->getHandlerClass('inline_form')) {
+      $entity_type->setHandlerClass('inline_form', '\Drupal\inline_entity_form\Form\EntityInlineForm');
+    }
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function inline_entity_form_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Attach the IEF handlers only if the current form has an IEF widget.
+  $widget_state = $form_state->get('inline_entity_form');
+  if (!is_null($widget_state)) {
+    ElementSubmit::attach($form, $form_state);
+    WidgetSubmit::attach($form, $form_state);
+  }
+}
+
+/**
+ * Implements hook_theme().
+ */
+function inline_entity_form_theme() {
+  return [
+    'inline_entity_form_entity_table' => [
+      'render element' => 'form',
+      'function' => 'theme_inline_entity_form_entity_table',
+    ],
+  ];
+}
+
+/**
+ * Provides the form for adding existing entities through an autocomplete field.
+ *
+ * @param array $reference_form
+ *   The form array that will receive the form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state of the parent form.
+ *
+ * @return array
+ *   The form array containing the embedded form.
+ */
+function inline_entity_form_reference_form($reference_form, &$form_state) {
+  $labels = $reference_form['#ief_labels'];
+  $ief_id = $reference_form['#ief_id'];
+  /** @var \Drupal\field\Entity\FieldConfig $instance */
+  $instance = $form_state->get(['inline_entity_form', $ief_id, 'instance']);
+
+  $reference_form['#title'] = t('Add existing @type_singular', ['@type_singular' => $labels['singular']]);
+  $reference_form['entity_id'] = [
+    '#type' => 'entity_autocomplete',
+    '#title' => t('@label', ['@label' => ucwords($labels['singular'])]),
+    '#target_type' => $instance->getSetting('target_type'),
+    '#selection_handler' => $instance->getSetting('handler'),
+    '#selection_settings' => $instance->getSetting('handler_settings'),
+    '#required' => TRUE,
+    '#maxlength' => 255,
+  ];
+  // Add the actions
+  $reference_form['actions'] = [
+    '#type' => 'container',
+    '#weight' => 100,
+  ];
+  $reference_form['actions']['ief_reference_save'] = [
+    '#type' => 'submit',
+    '#value' => t('Add @type_singular', ['@type_singular' => $labels['singular']]),
+    '#name' => 'ief-reference-submit-' . $reference_form['#ief_id'],
+    '#limit_validation_errors' => [$reference_form['#parents']],
+    '#attributes' => ['class' => ['ief-entity-submit']],
+    '#ajax' => [
+      'callback' => 'inline_entity_form_get_element',
+      'wrapper' => 'inline-entity-form-' . $reference_form['#ief_id'],
+    ],
+  ];
+  InlineEntityFormComplex::addSubmitCallbacks($reference_form['actions']['ief_reference_save']);
+  $reference_form['actions']['ief_reference_cancel'] = [
+    '#type' => 'submit',
+    '#value' => t('Cancel'),
+    '#name' => 'ief-reference-cancel-' . $reference_form['#ief_id'],
+    '#limit_validation_errors' => [],
+    '#ajax' => [
+      'callback' => 'inline_entity_form_get_element',
+      'wrapper' => 'inline-entity-form-' . $reference_form['#ief_id'],
+    ],
+    '#submit' => [['\Drupal\inline_entity_form\Plugin\Field\FieldWidget\InlineEntityFormComplex', 'closeForm']],
+  ];
+
+  $reference_form['#element_validate'][] = 'inline_entity_form_reference_form_validate';
+  $reference_form['#ief_element_submit'][] = 'inline_entity_form_reference_form_submit';
+
+  // Allow other modules to alter the form.
+  \Drupal::moduleHandler()->alter('inline_entity_form_reference_form', $reference_form, $form_state);
+
+  return $reference_form;
+}
+
+/**
+ * Validates the form for adding existing entities.
+ *
+ * @param array $reference_form
+ *  The reference entity form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state of the parent form.
+ */
+function inline_entity_form_reference_form_validate(&$reference_form, FormStateInterface $form_state) {
+  $form_values = NestedArray::getValue($form_state->getValues(), $reference_form['#parents']);
+  if (empty($form_values['entity_id'])) {
+    // The entity_id element is required, the value is empty only if
+    // the form was cancelled.
+    return;
+  }
+  $ief_id = $reference_form['#ief_id'];
+  $labels = $reference_form['#ief_labels'];
+  $storage = \Drupal::entityTypeManager()->getStorage($reference_form['#entity_type']);
+  $entity = $storage->load($form_values['entity_id']);
+
+  // Check if the entity is already referenced by the field.
+  if (!empty($entity)) {
+    foreach ($form_state->get(['inline_entity_form', $ief_id, 'entities']) as $key => $value) {
+      if ($value['entity'] && $value['entity']->id() == $entity->id()) {
+        $form_state->setError($reference_form['entity_id'], t('The selected @label has already been added.', ['@label' => $labels['singular']]));
+        break;
+      }
+    }
+  }
+}
+
+/**
+ * Submits the form for adding existing entities.
+ *
+ * Adds the specified entity to the IEF form state.
+ *
+ * @param array $reference_form
+ *  The reference entity form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state of the parent form.
+ */
+function inline_entity_form_reference_form_submit($reference_form, FormStateInterface $form_state) {
+  $ief_id = $reference_form['#ief_id'];
+  $form_values = NestedArray::getValue($form_state->getValues(), $reference_form['#parents']);
+  $storage = \Drupal::entityTypeManager()->getStorage($reference_form['#entity_type']);
+  $entity = $storage->load($form_values['entity_id']);
+  $entities = &$form_state->get(['inline_entity_form', $ief_id, 'entities']);
+  // Determine the correct weight of the new element.
+  $weight = 0;
+  if ($entities) {
+    $weight = max(array_keys($entities)) + 1;
+  }
+
+  $entities[] = [
+    'entity' => $entity,
+    '_weight' => $weight,
+    'form' => NULL,
+    'needs_save' => FALSE,
+  ];
+  $form_state->set(['inline_entity_form', $ief_id, 'entities'], $entities);
+}
+
+/**
+ * Button #submit callback: Opens a form in the IEF widget.
+ *
+ * The form is shown below the entity table, at the bottom of the widget.
+ *
+ * @param $form
+ *   The complete parent form.
+ * @param $form_state
+ *   The form state of the parent form.
+ */
+function inline_entity_form_open_form($form, FormStateInterface $form_state) {
+  $element = inline_entity_form_get_element($form, $form_state);
+  $ief_id = $element['#ief_id'];
+  $form_state->setRebuild();
+
+  // Get the current form values.
+  $parents = array_merge($element['#field_parents'], array($element['#field_name']));
+  $form_values = NestedArray::getValue($form_state->getUserInput(), $parents);
+
+  $triggering_element = $form_state->getTriggeringElement();
+  $form_state->set(['inline_entity_form', $ief_id, 'form'], $triggering_element['#ief_form']);
+  if (!empty($form_values['actions']['bundle'])) {
+    $form_state->set(['inline_entity_form', $ief_id, 'form settings'], array(
+      'bundle' => $form_values['actions']['bundle'],
+    ));
+  }
+}
+
+/**
+ * Button #submit callback: Cleans up form state for a closed entity form.
+ *
+ * @param $form
+ *   The complete parent form.
+ * @param $form_state
+ *   The form state of the parent form.
+ */
+function inline_entity_form_cleanup_form_state($form, FormStateInterface $form_state) {
+  $element = inline_entity_form_get_element($form, $form_state);
+  EntityInlineForm::submitCleanFormState($element['form']['inline_entity_form'], $form_state);
+}
+
+/**
+ * Button #submit callback: Opens a row form in the IEF widget.
+ *
+ * The row is identified by #ief_row_delta stored on the triggering
+ * element.
+ *
+ * @param $form
+ *   The complete parent form.
+ * @param $form_state
+ *   The form state of the parent form.
+ */
+function inline_entity_form_open_row_form($form, FormStateInterface $form_state) {
+  $element = inline_entity_form_get_element($form, $form_state);
+  $ief_id = $element['#ief_id'];
+  $delta = $form_state->getTriggeringElement()['#ief_row_delta'];
+
+  $form_state->setRebuild();
+  $form_state->set(['inline_entity_form', $ief_id, 'entities', $delta, 'form'], $form_state->getTriggeringElement()['#ief_row_form']);
+}
+
+
+/**
+ * Closes all open IEF forms.
+ *
+ * Recurses and closes open forms in nested IEF widgets as well.
+ *
+ * @param $elements
+ *   An array of form elements containing entity forms.
+ * @param $form_state
+ *   The form state of the parent form.
+ */
+function inline_entity_form_close_all_forms($elements, FormStateInterface $form_state) {
+  // Recurse through all children.
+  foreach (Element::children($elements) as $key) {
+    if (!empty($elements[$key])) {
+      inline_entity_form_close_all_forms($elements[$key], $form_state);
+    }
+  }
+
+  if (!empty($elements['#ief_id'])) {
+    $ief_id = $elements['#ief_id'];
+    // Close the main form.
+    $form_state->set(['inline_entity_form', $ief_id, 'form'], NULL);
+    // Close the row forms.
+    $entities = $form_state->get(['inline_entity_form', $ief_id, 'entities']);
+    foreach ($entities as $key => $value) {
+      $entities[$key]['form'] = NULL;
+    }
+    $form_state->set(['inline_entity_form', $ief_id, 'entities'], $entities);
+  }
+}
+
+/**
+ * Button #submit callback: Cleans up form state for a closed entity row form.
+ *
+ * @param $form
+ *   The complete parent form.
+ * @param $form_state
+ *   The form state of the parent form.
+ */
+function inline_entity_form_cleanup_row_form_state($form, FormStateInterface $form_state) {
+  $element = inline_entity_form_get_element($form, $form_state);
+  $delta = $form_state->getTriggeringElement()['#ief_row_delta'];
+  $entity_form = $element['entities'][$delta]['form']['inline_entity_form'];
+  EntityInlineForm::submitCleanFormState($entity_form, $form_state);
+}
+
+/**
+ * Returns an IEF widget nearest to the triggering element.
+ */
+function inline_entity_form_get_element($form, FormStateInterface $form_state) {
+  $element = array();
+  $triggering_element = $form_state->getTriggeringElement();
+
+  // Remove the action and the actions container.
+  $array_parents = array_slice($triggering_element['#array_parents'], 0, -2);
+
+  while (!isset($element['#ief_root'])) {
+    $element = NestedArray::getValue($form, $array_parents);
+    array_pop($array_parents);
+  }
+
+  return $element;
+}
+
+/**
+ * Themes the table showing existing entity references in the widget.
+ *
+ * @param array $variables
+ *   Contains the form element data from $element['entities'].
+ */
+function theme_inline_entity_form_entity_table($variables) {
+  $renderer = \Drupal::service('renderer');
+  $form = $variables['form'];
+  $entity_type = $form['#entity_type'];
+  $fields = $form['#table_fields'];
+  $has_tabledrag = inline_entity_form_has_tabledrag($form);
+  // Sort the fields by weight.
+  uasort($fields, '\Drupal\Component\Utility\SortArray::sortByWeightElement');
+
+  $header = [];
+  if ($has_tabledrag) {
+    $header[] = ['data' => '', 'class' => ['ief-tabledrag-header']];
+    $header[] = ['data' => t('Sort order'), 'class' => ['ief-sort-order-header']];
+  }
+  // Add header columns for each field.
+  $first = TRUE;
+  foreach ($fields as $field_name => $field) {
+    $column = ['data' => $field['label']];
+    // The first column gets a special class.
+    if ($first) {
+      $column['class'] = ['ief-first-column-header'];
+      $first = FALSE;
+    }
+    $header[] = $column;
+  }
+  $header[] = t('Operations');
+
+  // Build an array of entity rows for the table.
+  $rows = [];
+  foreach (Element::children($form) as $key) {
+    /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
+    $entity = $form[$key]['#entity'];
+    $row_classes = ['ief-row-entity'];
+    $cells = [];
+    if ($has_tabledrag) {
+      $cells[] = ['data' => '', 'class' => ['ief-tabledrag-handle']];
+      $cells[] = $renderer->render($form[$key]['delta']);
+      $row_classes[] = 'draggable';
+    }
+    // Add a special class to rows that have a form underneath, to allow
+    // for additional styling.
+    if (!empty($form[$key]['form'])) {
+      $row_classes[] = 'ief-row-entity-form';
+    }
+
+    foreach ($fields as $field_name => $field) {
+      $data = '';
+      if ($field['type'] == 'label') {
+        $data = $variables['form'][$key]['#label'];
+      }
+      elseif ($field['type'] == 'field' && $entity->hasField($field_name)) {
+        $display_options = ['label' => 'hidden'];
+        if (isset($field['display_options'])) {
+          $display_options += $field['display_options'];
+        }
+        $data = $entity->get($field_name)->view($display_options);
+      }
+      elseif ($field['type'] == 'callback') {
+        $arguments = [
+          'entity' => $entity,
+          'variables' => $variables,
+        ];
+        if (isset($field['callback_arguments'])) {
+          $arguments = array_merge($arguments, $field['callback_arguments']);
+        }
+
+        $data = call_user_func_array($field['callback'], $arguments);
+      }
+
+      $cells[] = ['data' => $data, 'class' => ['inline-entity-form-' . $entity_type . '-' . $field_name]];
+    }
+
+    // Add the buttons belonging to the "Operations" column.
+    $cells[] = $renderer->render($form[$key]['actions']);
+    // Create the row.
+    $rows[] = ['data' => $cells, 'class' => $row_classes];
+    // If the current entity array specifies a form, output it in the next row.
+    if (!empty($form[$key]['form'])) {
+      $row = [
+        ['data' => $renderer->render($form[$key]['form']), 'colspan' => count($fields) + 1],
+      ];
+      $rows[] = ['data' => $row, 'class' => ['ief-row-form'], 'no_striping' => TRUE];
+    }
+  }
+
+  if (!empty($rows)) {
+    $tabledrag = [];
+    if ($has_tabledrag) {
+      $tabledrag = [
+        [
+          'action' => 'order',
+          'relationship' => 'sibling',
+          'group' => 'ief-entity-delta',
+        ],
+      ];
+    }
+
+    $table = [
+      '#type' => 'table',
+      '#header' => $header,
+      '#rows' => $rows,
+      '#attributes' => [
+        'id' => 'ief-entity-table-' . $form['#id'],
+        'class' => ['ief-entity-table'],
+      ],
+      '#tabledrag' => $tabledrag,
+    ];
+
+    return $renderer->render($table);
+  }
+}
+
+/**
+ * Checks whether tabledrag should be enabled for the given table.
+ *
+ * @param array $element
+ *   The form element representing the IEF table.
+ *
+ * @return bool
+ *   TRUE if tabledrag should be enabled, FALSE otherwise.
+ */
+function inline_entity_form_has_tabledrag($element) {
+  $children = Element::children($element);
+  // If there is only one row, disable tabledrag.
+  if (count($children) == 1) {
+    return FALSE;
+  }
+  // If one of the rows is in form context, disable tabledrag.
+  foreach ($children as $key) {
+    if (!empty($element[$key]['form'])) {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/js/inline_entity_form.js
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/js/inline_entity_form.js
@@ -1,0 +1,29 @@
+/**
+ * @file
+ * Provides JavaScript for Inline Entity Form.
+ */
+
+(function ($) {
+
+/**
+ * Allows submit buttons in entity forms to trigger uploads by undoing
+ * work done by Drupal.behaviors.fileButtons.
+ */
+Drupal.behaviors.inlineEntityForm = {
+  attach: function (context) {
+    /*
+    if (Drupal.file) {
+      $('input.ief-entity-submit', context).unbind('mousedown', Drupal.file.disableFields);
+    }
+    */
+  },
+  detach: function (context) {
+    /*
+    if (Drupal.file) {
+      $('input.form-submit', context).bind('mousedown', Drupal.file.disableFields);
+    }
+    */
+  }
+};
+
+})(jQuery);

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Element/InlineEntityForm.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Element/InlineEntityForm.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Drupal\inline_entity_form\Element;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Render\Element;
+use Drupal\Core\Render\Element\RenderElement;
+use Drupal\inline_entity_form\ElementSubmit;
+
+/**
+ * Provides an inline entity form element.
+ *
+ * Usage example:
+ * @code
+ * $form['article'] = [
+ *   '#type' => 'inline_entity_form',
+ *   '#entity_type' => 'node',
+ *   '#bundle' => 'article',
+ *   // If the #default_value is NULL, a new entity will be created.
+ *   '#default_value' => $loaded_article,
+ * ];
+ * @endcode
+ * To access the entity in validation or submission callbacks, use
+ * $form['article']['#entity']. Due to Drupal core limitations the entity
+ * can't be accessed via $form_state->getValue('article').
+ *
+ * @RenderElement("inline_entity_form")
+ */
+class InlineEntityForm extends RenderElement {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getInfo() {
+    $class = get_class($this);
+    return [
+      '#ief_id' => '',
+      '#entity_type' => NULL,
+      '#bundle' => NULL,
+      '#language' => LanguageInterface::LANGCODE_NOT_SPECIFIED,
+      // Instance of \Drupal\Core\Entity\EntityInterface. If NULL, a new
+      // entity will be created.
+      '#default_value' => NULL,
+      // The form mode used to display the entity form.
+      '#form_mode' => 'default',
+      // Will save entity on submit if set to TRUE.
+      '#save_entity' => TRUE,
+      // 'add' or 'edit'. If NULL, determined by whether the entity is new.
+      '#op' => NULL,
+      '#process' => [
+        [$class, 'processEntityForm'],
+      ],
+      '#element_validate' => [
+        [$class, 'validateEntityForm'],
+      ],
+      '#ief_element_submit' => [
+        [$class, 'submitEntityForm'],
+      ],
+      '#theme_wrappers' => ['container'],
+      // Allow inline forms to use the #fieldset key.
+      '#pre_render' => [
+        [$class, 'addFieldsetMarkup'],
+      ],
+    ];
+  }
+
+  /**
+   * Builds the entity form using the inline form handler.
+   *
+   * @param array $entity_form
+   *   The entity form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   * @param array $complete_form
+   *   The complete form structure.
+   *
+   * @throws \InvalidArgumentException
+   *   Thrown when the #entity_type or #bundle properties are empty, or when
+   *   the #default_value property is not an entity.
+   *
+   * @return array
+   *   The built entity form.
+   */
+  public static function processEntityForm($entity_form, FormStateInterface $form_state, &$complete_form) {
+    if (empty($entity_form['#entity_type'])) {
+      throw new \InvalidArgumentException('The inline_entity_form element requires the #entity_type property.');
+    }
+    if (empty($entity_form['#bundle'])) {
+      throw new \InvalidArgumentException('The inline_entity_form element requires the #bundle property.');
+    }
+    if (isset($entity_form['#default_value']) && !($entity_form['#default_value'] instanceof EntityInterface)) {
+      throw new \InvalidArgumentException('The inline_entity_form #default_value property must be an entity object.');
+    }
+
+    if (empty($entity_form['#ief_id'])) {
+      $entity_form['#ief_id'] = \Drupal::service('uuid')->generate();
+    }
+    if (isset($entity_form['#default_value'])) {
+      // Transfer the #default_value to #entity, as expected by inline forms.
+      $entity_form['#entity'] = $entity_form['#default_value'];
+    }
+    else {
+      // This is an add operation, create a new entity.
+      $entity_type = \Drupal::entityTypeManager()->getDefinition($entity_form['#entity_type']);
+      $storage = \Drupal::entityTypeManager()->getStorage($entity_form['#entity_type']);
+      $values = [
+        'langcode' => $entity_form['#language'],
+      ];
+      if ($bundle_key = $entity_type->getKey('bundle')) {
+        $values[$bundle_key] = $entity_form['#bundle'];
+      }
+      $entity_form['#entity'] = $storage->create($values);
+    }
+    if (!isset($entity_form['#op'])) {
+      $entity_form['#op'] = $entity_form['#entity']->isNew() ? 'add' : 'edit';
+    }
+
+    $inline_form_handler = static::getInlineFormHandler($entity_form['#entity_type']);
+    $entity_form = $inline_form_handler->entityForm($entity_form, $form_state);
+    // The form element can't rely on inline_entity_form_form_alter() calling
+    // ElementSubmit::attach() since form alters run before #process callbacks.
+    ElementSubmit::attach($complete_form, $form_state);
+
+    return $entity_form;
+  }
+
+  /**
+   * Validates the entity form using the inline form handler.
+   *
+   * @param array $entity_form
+   *   The entity form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public static function validateEntityForm(&$entity_form, FormStateInterface $form_state) {
+    $inline_form_handler = static::getInlineFormHandler($entity_form['#entity_type']);
+    $inline_form_handler->entityFormValidate($entity_form, $form_state);
+  }
+
+  /**
+   * Handles the submission of the entity form using the inline form handler.
+   *
+   * @param array $entity_form
+   *   The entity form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public static function submitEntityForm(&$entity_form, FormStateInterface $form_state) {
+    $inline_form_handler = static::getInlineFormHandler($entity_form['#entity_type']);
+    $inline_form_handler->entityFormSubmit($entity_form, $form_state);
+    if ($entity_form['#save_entity']) {
+      $inline_form_handler->save($entity_form['#entity']);
+    }
+  }
+
+  /**
+   * Gets the inline form handler for the given entity type.
+   *
+   * @param string $entity_type
+   *   The entity type id.
+   *
+   * @throws \InvalidArgumentException
+   *   Thrown when the entity type has no inline form handler defined.
+   *
+   * @return \Drupal\inline_entity_form\InlineFormInterface
+   *   The inline form handler.
+   */
+  public static function getInlineFormHandler($entity_type) {
+    $inline_form_handler = \Drupal::entityTypeManager()->getHandler($entity_type, 'inline_form');
+    if (empty($inline_form_handler)) {
+      throw new \InvalidArgumentException(sprintf('The %s entity type has no inline form handler.', $entity_type));
+    }
+
+    return $inline_form_handler;
+  }
+
+  /**
+   * Pre-render callback for the #fieldset form property.
+   *
+   * Inline forms use #tree = TRUE to keep their values in a hierarchy for
+   * easier storage. Moving the form elements into fieldsets during form
+   * building would break up that hierarchy, so it's not an option for entity
+   * fields. Therefore, we wait until the pre_render stage, where any changes
+   * we make affect presentation only and aren't reflected in $form_state.
+   *
+   * @param array $entity_form
+   *   The entity form.
+   *
+   * @return array
+   *   The modified entity form.
+   */
+  public static function addFieldsetMarkup($entity_form) {
+    $sort = [];
+    foreach (Element::children($entity_form) as $key) {
+      $element = $entity_form[$key];
+      if (isset($element['#fieldset']) && isset($entity_form[$element['#fieldset']])) {
+        $entity_form[$element['#fieldset']][$key] = $element;
+        // Remove the original element this duplicates.
+        unset($entity_form[$key]);
+        // Mark the fieldset for sorting.
+        if (!in_array($key, $sort)) {
+          $sort[] = $element['#fieldset'];
+        }
+      }
+    }
+
+    // Sort all fieldsets, so that element #weight stays respected.
+    foreach ($sort as $key) {
+      uasort($entity_form[$key], '\Drupal\Component\Utility\SortArray::sortByWeightProperty');
+    }
+
+    return $entity_form;
+  }
+
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/src/ElementSubmit.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/src/ElementSubmit.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Drupal\inline_entity_form;
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+
+/**
+ * Provides #ief_element_submit, the submit version of #element_validate.
+ *
+ * #ief_element_submit callbacks are invoked by a #submit callback added
+ * to the form's main submit button.
+ */
+class ElementSubmit {
+
+  /**
+   * Attaches the #ief_element_submit functionality to the given form.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public static function attach(&$form, FormStateInterface $form_state) {
+    // attach() is called for each IEF form element, but the callbacks only
+    // need to be added once per form build.
+    if (isset($form['#ief_element_submit_attached'])) {
+      return;
+    }
+    $form['#ief_element_submit_attached'] = TRUE;
+
+    // Entity form actions.
+    foreach (['submit', 'publish', 'unpublish'] as $action) {
+      if (!empty($form['actions'][$action])) {
+        self::addCallback($form['actions'][$action], $form);
+      }
+    }
+    // Generic submit button.
+    if (!empty($form['submit'])) {
+      self::addCallback($form['submit'], $form);
+    }
+  }
+
+  /**
+   * Adds the trigger callback to the given submit element.
+   *
+   * @param array $element
+   *   The submit element.
+   * @param array $complete_form
+   *   The complete form.
+   */
+  public static function addCallback(&$element, $complete_form) {
+    if (empty($element['#submit'])) {
+      // Drupal runs either the button-level callbacks or the form-level ones.
+      // Having no button-level callbacks indicates that the form has relied
+      // on form-level callbacks, which now need to be transferred.
+      $element['#submit'] = $complete_form['#submit'];
+    }
+
+    $element['#submit'] = array_merge([[get_called_class(), 'trigger']], $element['#submit']);
+    // Used to distinguish between an inline form submit and main form submit.
+    $element['#ief_submit_trigger']  = TRUE;
+    $element['#ief_submit_trigger_all'] = TRUE;
+  }
+
+  /**
+   * Button #submit callback: Triggers submission of element forms.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public static function trigger($form, FormStateInterface $form_state) {
+    $triggered_element = $form_state->getTriggeringElement();
+    if (!empty($triggered_element['#ief_submit_trigger_all'])) {
+      // The parent form was submitted, process all IEFs and their children.
+      static::doSubmit($form, $form_state);
+    }
+    else {
+      // A specific element was submitted, process it and all of its children.
+      $array_parents = $triggered_element['#array_parents'];
+      $array_parents = array_slice($array_parents, 0, -2);
+      $element = NestedArray::getValue($form, $array_parents);
+      static::doSubmit($element, $form_state);
+    }
+  }
+
+  /**
+   * Submits elements by calling their #ief_element_submit callbacks.
+   *
+   * @param array $element
+   *   The element.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public static function doSubmit($element, FormStateInterface $form_state) {
+    // Recurse through all children.
+    foreach (Element::children($element) as $key) {
+      if (!empty($element[$key])) {
+        static::doSubmit($element[$key], $form_state);
+      }
+    }
+
+    // If there are callbacks on this level, run them.
+    if (!empty($element['#ief_element_submit'])) {
+      foreach ($element['#ief_element_submit'] as $callback) {
+        call_user_func_array($callback, [&$element, &$form_state]);
+      }
+    }
+  }
+
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Form/EntityInlineForm.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Form/EntityInlineForm.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace Drupal\inline_entity_form\Form;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\inline_entity_form\InlineFormInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Generic entity inline form handler.
+ */
+class EntityInlineForm implements InlineFormInterface {
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity type managed by this handler.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeInterface
+   */
+  protected $entityType;
+
+  /**
+   * Module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Constructs the inline entity form controller.
+   *
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The entity field manager.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type.
+   */
+  public function __construct(EntityFieldManagerInterface $entity_field_manager, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, EntityTypeInterface $entity_type) {
+    $this->entityFieldManager = $entity_field_manager;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->moduleHandler = $module_handler;
+    $this->entityType = $entity_type;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    return new static(
+      $container->get('entity_field.manager'),
+      $container->get('entity_type.manager'),
+      $container->get('module_handler'),
+      $entity_type
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityType() {
+    return $this->entityType;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityTypeLabels() {
+    $lowercase_label = $this->entityType->getLowercaseLabel();
+    return [
+      'singular' => $lowercase_label,
+      'plural' => t('@entity_type entities', ['@entity_type' => $lowercase_label]),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityLabel(EntityInterface $entity) {
+    return $entity->label();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTableFields($bundles) {
+    $definitions = $this->entityFieldManager->getBaseFieldDefinitions($this->entityType->id());
+    $label_key = $this->entityType->getKey('label');
+    $label_field_label = t('Label');
+    if ($label_key && isset($definitions[$label_key])) {
+      $label_field_label = $definitions[$label_key]->getLabel();
+    }
+    $bundle_key = $this->entityType->getKey('bundle');
+    $bundle_field_label = t('Type');
+    if ($bundle_key && isset($definitions[$bundle_key])) {
+      $bundle_field_label = $definitions[$bundle_key]->getLabel();
+    }
+
+    $fields = [];
+    $fields['label'] = [
+      'type' => 'label',
+      'label' => $label_field_label,
+      'weight' => 1,
+    ];
+    if (count($bundles) > 1) {
+      $fields[$bundle_key] = [
+        'type' => 'field',
+        'label' => $bundle_field_label,
+        'weight' => 2,
+        'display_options' => [
+          'type' => 'entity_reference_label',
+          'settings' => ['link' => FALSE],
+        ],
+      ];
+    }
+
+    return $fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function entityForm(array $entity_form, FormStateInterface $form_state) {
+    /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+    $entity = $entity_form['#entity'];
+    $form_display = $this->getFormDisplay($entity, $entity_form['#form_mode']);
+    $form_display->buildForm($entity, $entity_form, $form_state);
+    $entity_form['#ief_element_submit'][] = [get_class($this), 'submitCleanFormState'];
+    // Allow other modules to alter the form.
+    $this->moduleHandler->alter('inline_entity_form_entity_form', $entity_form, $form_state);
+
+    return $entity_form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function entityFormValidate(array &$entity_form, FormStateInterface $form_state) {
+    // Perform entity validation only if the inline form was submitted,
+    // skipping other requests such as file uploads.
+    $triggering_element = $form_state->getTriggeringElement();
+    if (!empty($triggering_element['#ief_submit_trigger'])) {
+      /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+      $entity = $entity_form['#entity'];
+      $this->buildEntity($entity_form, $entity, $form_state);
+      $form_display = $this->getFormDisplay($entity, $entity_form['#form_mode']);
+      $form_display->validateFormValues($entity, $entity_form, $form_state);
+      $entity->setValidationRequired(FALSE);
+
+      foreach($form_state->getErrors() as $name => $message) {
+        // $name may be unknown in $form_state and
+        // $form_state->setErrorByName($name, $message) may suppress the error message.
+        $form_state->setError($triggering_element, $message);
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function entityFormSubmit(array &$entity_form, FormStateInterface $form_state) {
+    $form_state->cleanValues();
+    /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+    $entity = $entity_form['#entity'];
+    $this->buildEntity($entity_form, $entity, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(EntityInterface $entity) {
+    $entity->save();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function delete($ids, $context) {
+    $storage_handler = $this->entityTypeManager->getStorage($this->entityType->id());
+    $entities = $storage_handler->loadMultiple($ids);
+    $storage_handler->delete($entities);
+  }
+
+  /**
+   * Builds an updated entity object based upon the submitted form values.
+   *
+   * @param array $entity_form
+   *   The entity form.
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  protected function buildEntity(array $entity_form, ContentEntityInterface $entity, FormStateInterface $form_state) {
+    $form_display = $this->getFormDisplay($entity, $entity_form['#form_mode']);
+    $form_display->extractFormValues($entity, $entity_form, $form_state);
+    // Invoke all specified builders for copying form values to entity fields.
+    if (isset($entity_form['#entity_builders'])) {
+      foreach ($entity_form['#entity_builders'] as $function) {
+        call_user_func_array($function, [$entity->getEntityTypeId(), $entity, &$entity_form, &$form_state]);
+      }
+    }
+  }
+
+  /**
+   * Cleans up the form state for a submitted entity form.
+   *
+   * After field_attach_submit() has run and the form has been closed, the form
+   * state still contains field data in $form_state->get('field'). Unless that
+   * data is removed, the next form with the same #parents (reopened add form,
+   * for example) will contain data (i.e. uploaded files) from the previous form.
+   *
+   * @param $entity_form
+   *   The entity form.
+   * @param $form_state
+   *   The form state of the parent form.
+   */
+  public static function submitCleanFormState(&$entity_form, FormStateInterface $form_state) {
+    $info = \Drupal::entityTypeManager()->getDefinition($entity_form['#entity_type']);
+    if (!$info->get('field_ui_base_route')) {
+      // The entity type is not fieldable, nothing to cleanup.
+      return;
+    }
+
+    $bundle = $entity_form['#entity']->bundle();
+    $instances = \Drupal::service('entity_field.manager')->getFieldDefinitions($entity_form['#entity_type'], $bundle);
+    foreach ($instances as $instance) {
+      $field_name = $instance->getName();
+      if (!empty($entity_form[$field_name]['#parents'])) {
+        $parents = $entity_form[$field_name]['#parents'];
+        array_pop($parents);
+        if (!empty($parents)) {
+          $field_state = array();
+          WidgetBase::setWidgetState($parents, $field_name, $form_state, $field_state);
+        }
+      }
+    }
+  }
+
+  /**
+   * Gets the form display for the given entity.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity.
+   * @param string $form_mode
+   *   The form mode.
+   *
+   * @return \Drupal\Core\Entity\Display\EntityFormDisplayInterface
+   *   The form display.
+   */
+  protected function getFormDisplay(ContentEntityInterface $entity, $form_mode) {
+    return EntityFormDisplay::collectRenderDisplay($entity, $form_mode);
+  }
+
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Form/NodeInlineForm.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Form/NodeInlineForm.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\inline_entity_form\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Node inline form handler.
+ */
+class NodeInlineForm extends EntityInlineForm {
+
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityTypeLabels() {
+    $labels = [
+      'singular' => $this->t('node'),
+      'plural' => $this->t('nodes'),
+    ];
+    return $labels;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTableFields($bundles) {
+    $fields = parent::getTableFields($bundles);
+
+    $fields['status'] = [
+      'type' => 'field',
+      'label' => $this->t('Status'),
+      'weight' => 100,
+      'display_options' => [
+        'settings' => [
+          'format' => 'custom',
+          'format_custom_false' => $this->t('Unpublished'),
+          'format_custom_true' => $this->t('Published'),
+        ],
+      ],
+    ];
+
+    return $fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function entityForm(array $entity_form, FormStateInterface $form_state) {
+    $entity_form = parent::entityForm($entity_form, $form_state);
+    // Remove the "Revision log" textarea,  it can't be disabled in the
+    // form display and doesn't make sense in the inline form context.
+    $entity_form['revision_log']['#access'] = FALSE;
+
+    return $entity_form;
+  }
+
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/src/InlineFormInterface.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/src/InlineFormInterface.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Drupal\inline_entity_form;
+
+use Drupal\Core\Entity\EntityHandlerInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Defines the interface for inline form handlers.
+ */
+interface InlineFormInterface extends EntityHandlerInterface {
+
+  /**
+   * Gets the entity type managed by this handler.
+   *
+   * @return \Drupal\Core\Entity\EntityTypeInterface
+   *   The entity type.
+   */
+  public function getEntityType();
+
+  /**
+   * Gets the entity type labels (singular, plural).
+   *
+   * @todo Remove when #1850080 lands and IEF starts requiring Drupal 8.1.x
+   *
+   * @return array
+   *   An array with two values:
+   *     - singular: The lowercase singular label.
+   *     - plural: The lowercase plural label.
+   */
+  public function getEntityTypeLabels();
+
+  /**
+   * Gets the label of the given entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The given entity.
+   *
+   * @return string
+   *   The entity label.
+   */
+  public function getEntityLabel(EntityInterface $entity);
+
+  /**
+   * Gets the fields used to represent an entity in the IEF table.
+   *
+   * Modules can alter the output of this method through
+   * hook_inline_entity_form_table_fields_alter().
+   *
+   * @param string[] $bundles
+   *   An array of allowed bundles for this widget.
+   *
+   * @return array
+   *   An array of fields keyed by field name. Each field is represented by an
+   *   associative array containing the following keys:
+   *   - type: 'label', 'field' or 'callback'.
+   *   - label: the title of the table field's column in the IEF table.
+   *   - weight: the sort order of the column in the IEF table.
+   *   - display_options: (optional) used for 'field' type table fields, an
+   *     array of display settings. See EntityViewBuilderInterface::viewField().
+   *   - callback: for 'callback' type table fields, a callable that returns a
+   *     renderable array.
+   *   - callback_arguments: (optional) an array of additional arguments to pass
+   *     to the callback. The entity and the theme variables are always passed
+   *     as as the first two arguments.
+   */
+  public function getTableFields($bundles);
+
+  /**
+   * Builds the entity form.
+   *
+   * @param array $entity_form
+   *   The entity form, containing the following basic properties:
+   *   - #entity: The entity for the current entity form.
+   *   - #op: The form operation. 'add' or 'edit'.
+   *   - #form_mode: The form mode used to display the entity form.
+   *   - #parents: Identifies the position of the entity form in the overall
+   *     parent form, and identifies the location where the field values are
+   *     placed within $form_state->getValues().
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state of the parent form.
+   */
+  public function entityForm(array $entity_form, FormStateInterface $form_state);
+
+  /**
+   * Validates the entity form.
+   *
+   * @param array $entity_form
+   *   The entity form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state of the parent form.
+   */
+  public function entityFormValidate(array &$entity_form, FormStateInterface $form_state);
+
+  /**
+   * Handles the submission of an entity form.
+   *
+   * @param array $entity_form
+   *   The entity form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state of the parent form.
+   */
+  public function entityFormSubmit(array &$entity_form, FormStateInterface $form_state);
+
+  /**
+   * Saves the given entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   *
+   * @return int
+   *   Either SAVED_NEW or SAVED_UPDATED, depending on the operation performed.
+   */
+  public function save(EntityInterface $entity);
+
+  /**
+   * Delete permanently saved entities.
+   *
+   * @param int[] $ids
+   *   An array of entity IDs.
+   * @param array $context
+   *   Available keys:
+   *   - parent_entity_type: The type of the parent entity.
+   *   - parent_entity: The parent entity.
+   */
+  public function delete($ids, $context);
+
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Plugin/Field/FieldWidget/InlineEntityFormBase.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Plugin/Field/FieldWidget/InlineEntityFormBase.php
@@ -1,0 +1,495 @@
+<?php
+
+namespace Drupal\inline_entity_form\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Inline entity form widget base class.
+ */
+abstract class InlineEntityFormBase extends WidgetBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The inline entity form id.
+   *
+   * @var string
+   */
+  protected $iefId;
+
+  /**
+   * The entity type bundle info.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  protected $entityTypeBundleInfo;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The inline entity from handler.
+   *
+   * @var \Drupal\inline_entity_form\InlineFormInterface
+   */
+  protected $inlineFormHandler;
+
+  /**
+   * The entity display repository.
+   *
+   * @var \Drupal\Core\Entity\EntityDisplayRepositoryInterface
+   */
+  protected $entityDisplayRepository;
+
+  /**
+   * Constructs an InlineEntityFormBase object.
+   *
+   * @param array $plugin_id
+   *   The plugin_id for the widget.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the widget is associated.
+   * @param array $settings
+   *   The widget settings.
+   * @param array $third_party_settings
+   *   Any third party settings.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle info.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityDisplayRepositoryInterface
+   *   The entity display repository.
+   */
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, array $third_party_settings, EntityTypeBundleInfoInterface $entity_type_bundle_info, EntityTypeManagerInterface $entity_type_manager, EntityDisplayRepositoryInterface $entity_display_repository) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings);
+
+    $this->entityTypeBundleInfo = $entity_type_bundle_info;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityDisplayRepository = $entity_display_repository;
+    $this->createInlineFormHandler();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['third_party_settings'],
+      $container->get('entity_type.bundle.info'),
+      $container->get('entity_type.manager'),
+      $container->get('entity_display.repository')
+    );
+  }
+
+  /**
+   * Creates an instance of the inline form handler for the current entity type.
+   */
+  protected function createInlineFormHandler() {
+    if (!isset($this->inlineFormHandler)) {
+      $target_type = $this->getFieldSetting('target_type');
+      $this->inlineFormHandler = $this->entityTypeManager->getHandler($target_type, 'inline_form');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __sleep() {
+    $keys = array_diff(parent::__sleep(), ['inlineFormHandler']);
+    return $keys;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __wakeup() {
+    parent::__wakeup();
+    $this->createInlineFormHandler();
+  }
+
+  /**
+   * Sets inline entity form ID.
+   *
+   * @param string $ief_id
+   *   The inline entity form ID.
+   */
+  protected function setIefId($ief_id) {
+    $this->iefId = $ief_id;
+  }
+
+  /**
+   * Gets inline entity form ID.
+   *
+   * @return string
+   *   Inline entity form ID.
+   */
+  protected function getIefId() {
+    return $this->iefId;
+  }
+
+  /**
+   * Gets the target bundles for the current field.
+   *
+   * @return string[]
+   *   A list of bundles.
+   */
+  protected function getTargetBundles() {
+    $settings = $this->getFieldSettings();
+    if (!empty($settings['handler_settings']['target_bundles'])) {
+      $target_bundles = array_values($settings['handler_settings']['target_bundles']);
+      // Filter out target bundles which no longer exist.
+      $existing_bundles = array_keys($this->entityTypeBundleInfo->getBundleInfo($settings['target_type']));
+      $target_bundles = array_intersect($target_bundles, $existing_bundles);
+    }
+    else {
+      // If no target bundles have been specified then all are available.
+      $target_bundles = array_keys($this->entityTypeBundleInfo->getBundleInfo($settings['target_type']));
+    }
+
+    return $target_bundles;
+  }
+
+  /**
+   * Gets the bundles for which the current user has create access.
+   *
+   * @return string[]
+   *   The list of bundles.
+   */
+  protected function getCreateBundles() {
+    $create_bundles = [];
+    foreach ($this->getTargetBundles() as $bundle) {
+      if ($this->getAccessHandler()->createAccess($bundle)) {
+        $create_bundles[] = $bundle;
+      }
+    }
+
+    return $create_bundles;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'form_mode' => 'default',
+      'override_labels' => FALSE,
+      'label_singular' => '',
+      'label_plural' => '',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $entity_type_id = $this->getFieldSetting('target_type');
+    $states_prefix = 'fields[' . $this->fieldDefinition->getName() . '][settings_edit_form][settings]';
+    $element = [];
+    $element['form_mode'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Form mode'),
+      '#default_value' => $this->getSetting('form_mode'),
+      '#options' => $this->entityDisplayRepository->getFormModeOptions($entity_type_id),
+      '#required' => TRUE,
+    ];
+    $element['override_labels'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Override labels'),
+      '#default_value' => $this->getSetting('override_labels'),
+    ];
+    $element['label_singular'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Singular label'),
+      '#default_value' => $this->getSetting('label_singular'),
+      '#states' => [
+        'visible' => [
+          ':input[name="' . $states_prefix . '[override_labels]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+    $element['label_plural'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Plural label'),
+      '#default_value' => $this->getSetting('label_plural'),
+      '#states' => [
+        'visible' => [
+          ':input[name="' . $states_prefix . '[override_labels]"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+    if ($entity_form_mode = $this->getEntityFormMode()) {
+      $form_mode_label = $entity_form_mode->label();
+    }
+    else {
+      $form_mode_label = $this->t('Default');
+    }
+    $summary[] = t('Form mode: @mode', ['@mode' => $form_mode_label]);
+    if ($this->getSetting('override_labels')) {
+      $summary[] = $this->t(
+        'Overriden labels are used: %singular and %plural',
+        ['%singular' => $this->getSetting('label_singular'), '%plural' => $this->getSetting('label_plural')]
+      );
+    }
+    else {
+      $summary[] = $this->t('Default labels are used.');
+    }
+
+    return $summary;
+  }
+
+  /**
+   * Gets the entity type managed by this handler.
+   *
+   * @return \Drupal\Core\Entity\EntityTypeInterface
+   *   The entity type.
+   */
+  protected function getEntityTypeLabels() {
+    // The admin has specified the exact labels that should be used.
+    if ($this->getSetting('override_labels')) {
+      return [
+        'singular' => $this->getSetting('label_singular'),
+        'plural' => $this->getSetting('label_plural'),
+      ];
+    }
+    else {
+      $this->createInlineFormHandler();
+      return $this->inlineFormHandler->getEntityTypeLabels();
+    }
+  }
+
+  /**
+   * Checks whether we can build entity form at all.
+   *
+   * - Is IEF handler loaded?
+   * - Are we on a "real" entity form and not on default value widget?
+   *
+   * @param FormStateInterface $form_state
+   *   Form state.
+   *
+   * @return bool
+   *   TRUE if we are able to proceed with form build and FALSE if not.
+   */
+  protected function canBuildForm(FormStateInterface $form_state) {
+    if ($this->isDefaultValueWidget($form_state)) {
+      return FALSE;
+    }
+
+    if (!$this->inlineFormHandler) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Prepares the form state for the current widget.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   * @param Drupal\Core\Field\FieldItemListInterface $items
+   *   The field values.
+   */
+  protected function prepareFormState(FormStateInterface $form_state, FieldItemListInterface $items) {
+    $widget_state = $form_state->get(['inline_entity_form', $this->iefId]);
+    if (empty($widget_state)) {
+      $widget_state = [
+        'instance' => $this->fieldDefinition,
+        'form' => NULL,
+        'delete' => [],
+        'entities' => [],
+      ];
+      // Store the $items entities in the widget state, for futher manipulation.
+      foreach ($items as $delta => $item) {
+        $entity = $item->entity;
+        // The $entity can be NULL if the reference is broken.
+        if ($entity) {
+          $widget_state['entities'][$delta] = [
+            'entity' => $entity,
+            '_weight' => $delta,
+            'form' => NULL,
+            'needs_save' => $entity->isNew(),
+          ];
+        }
+      }
+      $form_state->set(['inline_entity_form', $this->iefId], $widget_state);
+    }
+  }
+
+  /**
+   * Gets inline entity form element.
+   *
+   * @param string $operation
+   *   The operation (i.e. 'add' or 'edit').
+   * @param string $bundle
+   *   Entity bundle.
+   * @param string $language
+   *   Entity langcode.
+   * @param array $parents
+   *   Array of parent element names.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Optional entity object.
+   *
+   * @return array
+   *   IEF form element structure.
+   */
+  protected function getInlineEntityForm($operation, $bundle, $language, $delta, array $parents, EntityInterface $entity = NULL) {
+    $element = [
+      '#type' => 'inline_entity_form',
+      '#entity_type' => $this->getFieldSetting('target_type'),
+      '#bundle' => $bundle,
+      '#language' => $language,
+      '#default_value' => $entity,
+      '#op' => $operation,
+      '#form_mode' => $this->getSetting('form_mode'),
+      '#save_entity' => FALSE,
+      '#ief_row_delta' => $delta,
+      // Used by Field API and controller methods to find the relevant
+      // values in $form_state.
+      '#parents' => $parents,
+      // Labels could be overridden in field widget settings. We won't have
+      // access to those in static callbacks (#process, ...) so let's add
+      // them here.
+      '#ief_labels' => $this->getEntityTypeLabels(),
+      // Identifies the IEF widget to which the form belongs.
+      '#ief_id' => $this->getIefId(),
+    ];
+
+    return $element;
+  }
+
+  /**
+   * Adds submit callbacks to the inline entity form.
+   *
+   * @param array $element
+   *   Form array structure.
+   */
+  public static function addIefSubmitCallbacks($element) {
+    $element['#ief_element_submit'][] = [get_called_class(), 'submitSaveEntity'];
+    return $element;
+  }
+
+  /**
+   * Marks created/edited entity with "needs save" flag.
+   *
+   * Note that at this point the entity is not yet saved, since the user might
+   * still decide to cancel the parent form.
+   *
+   * @param $entity_form
+   *  The form of the entity being managed inline.
+   * @param $form_state
+   *   The form state of the parent form.
+   */
+  public static function submitSaveEntity($entity_form, FormStateInterface $form_state) {
+    $ief_id = $entity_form['#ief_id'];
+    /** @var \Drupal\Core\Entity\EntityInterface $entity */
+    $entity = $entity_form['#entity'];
+
+    if ($entity_form['#op'] == 'add') {
+      // Determine the correct weight of the new element.
+      $weight = 0;
+      $entities = $form_state->get(['inline_entity_form', $ief_id, 'entities']);
+      if (!empty($entities)) {
+        $weight = max(array_keys($entities)) + 1;
+      }
+      // Add the entity to form state, mark it for saving, and close the form.
+      $entities[] = [
+        'entity' => $entity,
+        '_weight' => $weight,
+        'form' => NULL,
+        'needs_save' => TRUE,
+      ];
+      $form_state->set(['inline_entity_form', $ief_id, 'entities'], $entities);
+    }
+    else {
+      $delta = $entity_form['#ief_row_delta'];
+      $entities = $form_state->get(['inline_entity_form', $ief_id, 'entities']);
+      $entities[$delta]['entity'] = $entity;
+      $entities[$delta]['needs_save'] = TRUE;
+      $form_state->set(['inline_entity_form', $ief_id, 'entities'], $entities);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function calculateDependencies() {
+    $dependencies = parent::calculateDependencies();
+    if ($entity_form_mode = $this->getEntityFormMode()) {
+      $dependencies['config'][] = $entity_form_mode->getConfigDependencyName();
+    }
+    return $dependencies;
+  }
+
+  /**
+   * Gets the entity form mode instance for this widget.
+   *
+   * @return \Drupal\Core\Entity\EntityFormModeInterface|null
+   *   The form mode instance, or NULL if the default one is used.
+   */
+  protected function getEntityFormMode() {
+    $form_mode = $this->getSetting('form_mode');
+    if ($form_mode != 'default') {
+      $entity_type_id = $this->getFieldSetting('target_type');
+      return $this->entityTypeManager->getStorage('entity_form_mode')->load($entity_type_id . '.' . $form_mode);
+    }
+    return NULL;
+  }
+
+  /**
+   * Gets the access handler for the target entity type.
+   *
+   * @return \Drupal\Core\Entity\EntityAccessControlHandlerInterface
+   *   The access handler.
+   */
+  protected function getAccessHandler() {
+    $entity_type_id = $this->getFieldSetting('target_type');
+    return $this->entityTypeManager->getAccessControlHandler($entity_type_id);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(FieldItemListInterface $items, array &$form, FormStateInterface $form_state, $get_delta = NULL) {
+    if ($this->canBuildForm($form_state)) {
+      return parent::form($items, $form, $form_state, $get_delta);
+    }
+    return [];
+  }
+
+  /**
+   * Determines if the current user can add any new entities.
+   *
+   * @return bool
+   */
+  protected function canAddNew() {
+    $create_bundles = $this->getCreateBundles();
+    return !empty($create_bundles);
+  }
+
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Plugin/Field/FieldWidget/InlineEntityFormComplex.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Plugin/Field/FieldWidget/InlineEntityFormComplex.php
@@ -1,0 +1,945 @@
+<?php
+
+namespace Drupal\inline_entity_form\Plugin\Field\FieldWidget;
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Component\Utility\SortArray;
+use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Render\Element;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Complex inline widget.
+ *
+ * @FieldWidget(
+ *   id = "inline_entity_form_complex",
+ *   label = @Translation("Inline entity form - Complex"),
+ *   field_types = {
+ *     "entity_reference"
+ *   },
+ *   multiple_values = true
+ * )
+ */
+class InlineEntityFormComplex extends InlineEntityFormBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Constructs a InlineEntityFormBase object.
+   *
+   * @param array $plugin_id
+   *   The plugin_id for the widget.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the widget is associated.
+   * @param array $settings
+   *   The widget settings.
+   * @param array $third_party_settings
+   *   Any third party settings.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle info.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityDisplayRepositoryInterface
+   *   The entity display repository.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   Module handler service.
+   */
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, array $third_party_settings, EntityTypeBundleInfoInterface $entity_type_bundle_info, EntityTypeManagerInterface $entity_type_manager, EntityDisplayRepositoryInterface $entity_display_repository, ModuleHandlerInterface $module_handler) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings, $entity_type_bundle_info, $entity_type_manager, $entity_display_repository);
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['third_party_settings'],
+      $container->get('entity_type.bundle.info'),
+      $container->get('entity_type.manager'),
+      $container->get('entity_display.repository'),
+      $container->get('module_handler')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    $defaults = parent::defaultSettings();
+    $defaults += [
+      'allow_new' => TRUE,
+      'allow_existing' => FALSE,
+      'match_operator' => 'CONTAINS',
+    ];
+
+    return $defaults;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $element = parent::settingsForm($form, $form_state);
+
+    $labels = $this->getEntityTypeLabels();
+    $states_prefix = 'fields[' . $this->fieldDefinition->getName() . '][settings_edit_form][settings]';
+    $element['allow_new'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Allow users to add new @label.', array('@label' => $labels['plural'])),
+      '#default_value' => $this->getSetting('allow_new'),
+    ];
+    $element['allow_existing'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Allow users to add existing @label.', ['@label' => $labels['plural']]),
+      '#default_value' => $this->getSetting('allow_existing'),
+    ];
+    $element['match_operator'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Autocomplete matching'),
+      '#default_value' => $this->getSetting('match_operator'),
+      '#options' => $this->getMatchOperatorOptions(),
+      '#description' => $this->t('Select the method used to collect autocomplete suggestions. Note that <em>Contains</em> can cause performance issues on sites with thousands of nodes.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="' . $states_prefix . '[allow_existing]"]' => array('checked' => TRUE),
+        ],
+      ],
+    ];
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = parent::settingsSummary();
+    $labels = $this->getEntityTypeLabels();
+
+    if ($this->getSetting('allow_new')) {
+      $summary[] = $this->t('New @label can be added.', ['@label' => $labels['plural']]);
+    }
+    else {
+      $summary[] = $this->t('New @label can not be created.', ['@label' => $labels['plural']]);
+    }
+
+    $match_operator_options = $this->getMatchOperatorOptions();
+    if ($this->getSetting('allow_existing')) {
+      $summary[] = $this->t('Existing @label can be referenced and are matched with the %operator operator.', [
+        '@label' => $labels['plural'],
+        '%operator' => $match_operator_options[$this->getSetting('match_operator')],
+      ]);
+    }
+    else {
+      $summary[] = $this->t('Existing @label can not be referenced.', ['@label' => $labels['plural']]);
+    }
+
+    return $summary;
+  }
+
+  /**
+   * Returns the options for the match operator.
+   *
+   * @return array
+   *   List of options.
+   */
+  protected function getMatchOperatorOptions() {
+    return [
+      'STARTS_WITH' => $this->t('Starts with'),
+      'CONTAINS' => $this->t('Contains'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $settings = $this->getSettings();
+    $target_type = $this->getFieldSetting('target_type');
+    // Get the entity type labels for the UI strings.
+    $labels = $this->getEntityTypeLabels();
+
+    // Build a parents array for this element's values in the form.
+    $parents = array_merge($element['#field_parents'], array(
+      $items->getName(),
+      'form',
+    ));
+
+    // Assign a unique identifier to each IEF widget.
+    // Since $parents can get quite long, sha1() ensures that every id has
+    // a consistent and relatively short length while maintaining uniqueness.
+    $this->setIefId(sha1(implode('-', $parents)));
+
+    // Get the langcode of the parent entity.
+    $parent_langcode = $items->getParent()->getValue()->language()->getId();
+
+    // Determine the wrapper ID for the entire element.
+    $wrapper = 'inline-entity-form-' . $this->getIefId();
+
+    $element = array(
+        '#type' => 'fieldset',
+        '#tree' => TRUE,
+        '#description' => NULL,
+        '#prefix' => '<div id="' . $wrapper . '">',
+        '#suffix' => '</div>',
+        '#ief_id' => $this->getIefId(),
+        '#ief_root' => TRUE,
+      ) + $element;
+
+    $element['#attached']['library'][] = 'inline_entity_form/widget';
+
+    $this->prepareFormState($form_state, $items);
+    $entities = $form_state->get(['inline_entity_form', $this->getIefId(), 'entities']);
+
+    // Build the "Multiple value" widget.
+    // TODO - does this belong in #element_validate?
+    $element['#element_validate'][] = [get_class($this), 'updateRowWeights'];
+    // Add the required element marker & validation.
+    if ($element['#required']) {
+      $element['#element_validate'][] = [get_class($this), 'requiredField'];
+    }
+
+    $element['entities'] = array(
+      '#tree' => TRUE,
+      '#theme' => 'inline_entity_form_entity_table',
+      '#entity_type' => $target_type,
+    );
+
+    // Get the fields that should be displayed in the table.
+    $target_bundles = $this->getTargetBundles();
+    $create_bundles = $this->getCreateBundles();
+    $create_bundles_count = count($create_bundles);
+    $allow_new = $settings['allow_new'] && !empty($create_bundles);
+    $fields = $this->inlineFormHandler->getTableFields($target_bundles);
+    $context = array(
+      'parent_entity_type' => $this->fieldDefinition->getTargetEntityTypeId(),
+      'parent_bundle' => $this->fieldDefinition->getTargetBundle(),
+      'field_name' => $this->fieldDefinition->getName(),
+      'entity_type' => $target_type,
+      'allowed_bundles' => $target_bundles,
+    );
+    $this->moduleHandler->alter('inline_entity_form_table_fields', $fields, $context);
+    $element['entities']['#table_fields'] = $fields;
+
+    $weight_delta = max(ceil(count($entities) * 1.2), 50);
+    foreach ($entities as $key => $value) {
+      // Data used by theme_inline_entity_form_entity_table().
+      /** @var \Drupal\Core\Entity\EntityInterface $entity */
+      $entity = $value['entity'];
+      $element['entities'][$key]['#label'] = $this->inlineFormHandler->getEntityLabel($value['entity']);
+      $element['entities'][$key]['#entity'] = $value['entity'];
+      $element['entities'][$key]['#needs_save'] = $value['needs_save'];
+
+      // Handle row weights.
+      $element['entities'][$key]['#weight'] = $value['_weight'];
+
+      // First check to see if this entity should be displayed as a form.
+      if (!empty($value['form'])) {
+        $element['entities'][$key]['title'] = array();
+        $element['entities'][$key]['delta'] = array(
+          '#type' => 'value',
+          '#value' => $value['_weight'],
+        );
+
+        // Add the appropriate form.
+        if ($value['form'] == 'edit') {
+          $element['entities'][$key]['form'] = [
+            '#type' => 'container',
+            '#attributes' => ['class' => ['ief-form', 'ief-form-row']],
+            'inline_entity_form' => $this->getInlineEntityForm(
+              $value['form'],
+              $entity->bundle(),
+              $parent_langcode,
+              $key,
+              array_merge($parents,  ['inline_entity_form', 'entities', $key, 'form']),
+              $entity
+            ),
+          ];
+
+          $element['entities'][$key]['form']['inline_entity_form']['#process'] = [
+            ['\Drupal\inline_entity_form\Element\InlineEntityForm', 'processEntityForm'],
+            [get_class($this), 'addIefSubmitCallbacks'],
+            [get_class($this), 'buildEntityFormActions'],
+          ];
+        }
+        elseif ($value['form'] == 'remove') {
+          $element['entities'][$key]['form'] = [
+            '#type' => 'container',
+            '#attributes' => ['class' => ['ief-form', 'ief-form-row']],
+            // Used by Field API and controller methods to find the relevant
+            // values in $form_state.
+            '#parents' => array_merge($parents, ['entities', $key, 'form']),
+            // Store the entity on the form, later modified in the controller.
+            '#entity' => $entity,
+            // Identifies the IEF widget to which the form belongs.
+            '#ief_id' => $this->getIefId(),
+            // Identifies the table row to which the form belongs.
+            '#ief_row_delta' => $key,
+          ];
+          $this->buildRemoveForm($element['entities'][$key]['form']);
+        }
+      }
+      else {
+        $row = &$element['entities'][$key];
+        $row['title'] = array();
+        $row['delta'] = array(
+          '#type' => 'weight',
+          '#delta' => $weight_delta,
+          '#default_value' => $value['_weight'],
+          '#attributes' => array('class' => array('ief-entity-delta')),
+        );
+        // Add an actions container with edit and delete buttons for the entity.
+        $row['actions'] = array(
+          '#type' => 'container',
+          '#attributes' => array('class' => array('ief-entity-operations')),
+        );
+
+        // Make sure entity_access is not checked for unsaved entities.
+        $entity_id = $entity->id();
+        if (empty($entity_id) || $entity->access('update')) {
+          $row['actions']['ief_entity_edit'] = array(
+            '#type' => 'submit',
+            '#value' => $this->t('Edit'),
+            '#name' => 'ief-' . $this->getIefId() . '-entity-edit-' . $key,
+            '#limit_validation_errors' => array(),
+            '#ajax' => array(
+              'callback' => 'inline_entity_form_get_element',
+              'wrapper' => $wrapper,
+            ),
+            '#submit' => array('inline_entity_form_open_row_form'),
+            '#ief_row_delta' => $key,
+            '#ief_row_form' => 'edit',
+          );
+        }
+
+        // If 'allow_existing' is on, the default removal operation is unlink
+        // and the access check for deleting happens inside the controller
+        // removeForm() method.
+        if (empty($entity_id) || $settings['allow_existing'] || $entity->access('delete')) {
+          $row['actions']['ief_entity_remove'] = array(
+            '#type' => 'submit',
+            '#value' => $this->t('Remove'),
+            '#name' => 'ief-' . $this->getIefId() . '-entity-remove-' . $key,
+            '#limit_validation_errors' => array(),
+            '#ajax' => array(
+              'callback' => 'inline_entity_form_get_element',
+              'wrapper' => $wrapper,
+            ),
+            '#submit' => array('inline_entity_form_open_row_form'),
+            '#ief_row_delta' => $key,
+            '#ief_row_form' => 'remove',
+          );
+        }
+      }
+    }
+
+    $entities_count = count($entities);
+    $cardinality = $this->fieldDefinition->getFieldStorageDefinition()->getCardinality();
+    if ($cardinality > 1) {
+      // Add a visual cue of cardinality count.
+      $message = $this->t('You have added @entities_count out of @cardinality_count allowed @label.', array(
+        '@entities_count' => $entities_count,
+        '@cardinality_count' => $cardinality,
+        '@label' => $labels['plural'],
+      ));
+      $element['cardinality_count'] = array(
+        '#markup' => '<div class="ief-cardinality-count">' . $message . '</div>',
+      );
+    }
+    // Do not return the rest of the form if cardinality count has been reached.
+    if ($cardinality > 0 && $entities_count == $cardinality) {
+      return $element;
+    }
+
+    $hide_cancel = FALSE;
+
+    // If the field is required and empty try to open one of the forms.
+    if (empty($entities) && $this->fieldDefinition->isRequired()) {
+      if ($settings['allow_existing'] && !$allow_new) {
+        $form_state->set(['inline_entity_form', $this->getIefId(), 'form'], 'ief_add_existing');
+        $hide_cancel = TRUE;
+      }
+      elseif ($create_bundles_count == 1 && $allow_new && !$settings['allow_existing']) {
+        $bundle = reset($target_bundles);
+
+        // The parent entity type and bundle must not be the same as the inline
+        // entity type and bundle, to prevent recursion.
+        $parent_entity_type = $this->fieldDefinition->getTargetEntityTypeId();
+        $parent_bundle =  $this->fieldDefinition->getTargetBundle();
+        if ($parent_entity_type != $target_type || $parent_bundle != $bundle) {
+          $form_state->set(['inline_entity_form', $this->getIefId(), 'form'], 'add');
+          $form_state->set(['inline_entity_form', $this->getIefId(), 'form settings'], array(
+            'bundle' => $bundle,
+          ));
+          $hide_cancel = TRUE;
+        }
+      }
+    }
+
+    // If no form is open, show buttons that open one.
+    $open_form = $form_state->get(['inline_entity_form', $this->getIefId(), 'form']);
+
+    if (empty($open_form)) {
+      $element['actions'] = array(
+        '#attributes' => array('class' => array('container-inline')),
+        '#type' => 'container',
+        '#weight' => 100,
+      );
+
+      // The user is allowed to create an entity of at least one bundle.
+      if ($allow_new) {
+        // Let the user select the bundle, if multiple are available.
+        if ($create_bundles_count > 1) {
+          $bundles = array();
+          foreach ($this->entityTypeBundleInfo->getBundleInfo($target_type) as $bundle_name => $bundle_info) {
+            if (in_array($bundle_name, $create_bundles)) {
+              $bundles[$bundle_name] = $bundle_info['label'];
+            }
+          }
+          asort($bundles);
+
+          $element['actions']['bundle'] = array(
+            '#type' => 'select',
+            '#options' => $bundles,
+          );
+        }
+        else {
+          $element['actions']['bundle'] = array(
+            '#type' => 'value',
+            '#value' => reset($create_bundles),
+          );
+        }
+
+        $element['actions']['ief_add'] = array(
+          '#type' => 'submit',
+          '#value' => $this->t('Add new @type_singular', array('@type_singular' => $labels['singular'])),
+          '#name' => 'ief-' . $this->getIefId() . '-add',
+          '#limit_validation_errors' => array(array_merge($parents, array('actions'))),
+          '#ajax' => array(
+            'callback' => 'inline_entity_form_get_element',
+            'wrapper' => $wrapper,
+          ),
+          '#submit' => array('inline_entity_form_open_form'),
+          '#ief_form' => 'add',
+        );
+      }
+
+      if ($settings['allow_existing']) {
+        $element['actions']['ief_add_existing'] = array(
+          '#type' => 'submit',
+          '#value' => $this->t('Add existing @type_singular', array('@type_singular' => $labels['singular'])),
+          '#name' => 'ief-' . $this->getIefId() . '-add-existing',
+          '#limit_validation_errors' => array(array_merge($parents, array('actions'))),
+          '#ajax' => array(
+            'callback' => 'inline_entity_form_get_element',
+            'wrapper' => $wrapper,
+          ),
+          '#submit' => array('inline_entity_form_open_form'),
+          '#ief_form' => 'ief_add_existing',
+        );
+      }
+    }
+    else {
+      // There's a form open, show it.
+      if ($form_state->get(['inline_entity_form', $this->getIefId(), 'form']) == 'add') {
+        $element['form'] = [
+          '#type' => 'fieldset',
+          '#attributes' => ['class' => ['ief-form', 'ief-form-bottom']],
+          'inline_entity_form' => $this->getInlineEntityForm(
+            'add',
+            $this->determineBundle($form_state),
+            $parent_langcode,
+            NULL,
+            array_merge($parents, ['inline_entity_form'])
+          )
+        ];
+        $element['form']['inline_entity_form']['#process'] = [
+          ['\Drupal\inline_entity_form\Element\InlineEntityForm', 'processEntityForm'],
+          [get_class($this), 'addIefSubmitCallbacks'],
+          [get_class($this), 'buildEntityFormActions'],
+        ];
+      }
+      elseif ($form_state->get(['inline_entity_form', $this->getIefId(), 'form']) == 'ief_add_existing') {
+        $element['form'] = array(
+          '#type' => 'fieldset',
+          '#attributes' => array('class' => array('ief-form', 'ief-form-bottom')),
+          // Identifies the IEF widget to which the form belongs.
+          '#ief_id' => $this->getIefId(),
+          // Used by Field API and controller methods to find the relevant
+          // values in $form_state.
+          '#parents' => array_merge($parents),
+          // Pass the current entity type.
+          '#entity_type' => $target_type,
+          // Pass the langcode of the parent entity,
+          '#parent_language' => $parent_langcode,
+          // Pass the widget specific labels.
+          '#ief_labels' => $this->getEntityTypeLabels(),
+        );
+
+        $element['form'] += inline_entity_form_reference_form($element['form'], $form_state);
+      }
+
+      // Pre-opened forms can't be closed in order to force the user to
+      // add / reference an entity.
+      if ($hide_cancel) {
+        if ($open_form == 'add') {
+          $process_element = &$element['form']['inline_entity_form'];
+        }
+        elseif ($open_form == 'ief_add_existing') {
+          $process_element = &$element['form'];
+        }
+        $process_element['#process'][] = [get_class($this), 'hideCancel'];
+      }
+
+      // No entities have been added. Remove the outer fieldset to reduce
+      // visual noise caused by having two titles.
+      if (empty($entities)) {
+        $element['#type'] = 'container';
+      }
+    }
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function extractFormValues(FieldItemListInterface $items, array $form, FormStateInterface $form_state) {
+    if ($this->isDefaultValueWidget($form_state)) {
+      $items->filterEmptyItems();
+      return;
+    }
+
+    $trigger = $form_state->getTriggeringElement();
+    if (empty($trigger['#ief_submit_trigger'])) {
+      return;
+    }
+
+    $field_name = $this->fieldDefinition->getName();
+    $parents = array_merge($form['#parents'], [$field_name, 'form']);
+    $ief_id = sha1(implode('-', $parents));
+    $this->setIefId($ief_id);
+
+    $inline_entity_form_state = $form_state->get('inline_entity_form');
+    if (isset($inline_entity_form_state[$this->getIefId()])) {
+      $values = $inline_entity_form_state[$this->getIefId()];
+      $key_exists = TRUE;
+    }
+    else {
+      $values = [];
+      $key_exists = FALSE;
+    }
+
+    if ($key_exists) {
+      // If the inline entity form is still open, then its entity hasn't
+      // been transfered to the IEF form state yet.
+      if (empty($values['entities']) && !empty($values['form'])) {
+        // @todo Do the same for reference forms.
+        if ($values['form'] == 'add') {
+          $element = NestedArray::getValue($form, [$field_name, 'widget', 'form']);
+          $entity = $element['inline_entity_form']['#entity'];
+          $values['entities'][] = ['entity' => $entity];
+        }
+      }
+
+      $values = $values['entities'];
+      // Account for drag-and-drop reordering if needed.
+      if (!$this->handlesMultipleValues()) {
+        // Remove the 'value' of the 'add more' button.
+        unset($values['add_more']);
+
+        // The original delta, before drag-and-drop reordering, is needed to
+        // route errors to the corect form element.
+        foreach ($values as $delta => &$value) {
+          $value['_original_delta'] = $delta;
+        }
+
+        usort($values, function ($a, $b) {
+          return SortArray::sortByKeyInt($a, $b, '_weight');
+        });
+      }
+
+      // Let the widget massage the submitted values.
+      $values = $this->massageFormValues($values, $form, $form_state);
+
+      // Assign the values and remove the empty ones.
+      $items->setValue($values);
+      $items->filterEmptyItems();
+
+      // Put delta mapping in $form_state, so that flagErrors() can use it.
+      $field_state = WidgetBase::getWidgetState($form['#parents'], $field_name, $form_state);
+      foreach ($items as $delta => $item) {
+        $field_state['original_deltas'][$delta] = isset($item->_original_delta) ? $item->_original_delta : $delta;
+        unset($item->_original_delta, $item->_weight);
+      }
+
+      WidgetBase::setWidgetState($form['#parents'], $field_name, $form_state, $field_state);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+    $items = array();
+
+    // Convert form values to actual entity reference values.
+    foreach ($values as $value) {
+      $item = $value;
+      if (isset($item['entity'])) {
+        $item['target_id'] = $item['entity']->id();
+        $items[] = $item;
+      }
+      else {
+        $item['target_id'] = NULL;
+        $items[] = $item;
+      }
+    }
+
+    // Sort items by _weight.
+    usort($items, function ($a, $b) {
+      return SortArray::sortByKeyInt($a, $b, '_weight');
+    });
+
+    return $items;
+  }
+
+  /**
+   * Adds actions to the inline entity form.
+   *
+   * @param array $element
+   *   Form array structure.
+   */
+  public static function buildEntityFormActions($element) {
+    // Build a delta suffix that's appended to button #name keys for uniqueness.
+    $delta = $element['#ief_id'];
+    if ($element['#op'] == 'add') {
+      $save_label = t('Create @type_singular', ['@type_singular' => $element['#ief_labels']['singular']]);
+    }
+    else {
+      $delta .= '-' . $element['#ief_row_delta'];
+      $save_label = t('Update @type_singular', ['@type_singular' => $element['#ief_labels']['singular']]);
+    }
+
+    // Add action submit elements.
+    $element['actions'] = [
+      '#type' => 'container',
+      '#weight' => 100,
+    ];
+    $element['actions']['ief_' . $element['#op'] . '_save'] = [
+      '#type' => 'submit',
+      '#value' => $save_label,
+      '#name' => 'ief-' . $element['#op'] . '-submit-' . $delta,
+      '#limit_validation_errors' => [$element['#parents']],
+      '#attributes' => ['class' => ['ief-entity-submit']],
+      '#ajax' => [
+        'callback' => 'inline_entity_form_get_element',
+        'wrapper' => 'inline-entity-form-' . $element['#ief_id'],
+      ],
+    ];
+    $element['actions']['ief_' . $element['#op'] . '_cancel'] = [
+      '#type' => 'submit',
+      '#value' => t('Cancel'),
+      '#name' => 'ief-' . $element['#op'] . '-cancel-' . $delta,
+      '#limit_validation_errors' => [],
+      '#ajax' => [
+        'callback' => 'inline_entity_form_get_element',
+        'wrapper' => 'inline-entity-form-' . $element['#ief_id'],
+      ],
+    ];
+
+    // Add submit handlers depending on operation.
+    if ($element['#op'] == 'add') {
+      static::addSubmitCallbacks($element['actions']['ief_add_save']);
+      $element['actions']['ief_add_cancel']['#submit'] = [
+        [get_called_class(), 'closeChildForms'],
+        [get_called_class(), 'closeForm'],
+        'inline_entity_form_cleanup_form_state',
+      ];
+    }
+    else {
+      $element['actions']['ief_edit_save']['#ief_row_delta'] = $element['#ief_row_delta'];
+      $element['actions']['ief_edit_cancel']['#ief_row_delta'] = $element['#ief_row_delta'];
+
+      static::addSubmitCallbacks($element['actions']['ief_edit_save']);
+      $element['actions']['ief_edit_save']['#submit'][] = [get_called_class(), 'submitCloseRow'];
+      $element['actions']['ief_edit_cancel']['#submit'] = [
+        [get_called_class(), 'closeChildForms'],
+        [get_called_class(), 'submitCloseRow'],
+        'inline_entity_form_cleanup_row_form_state',
+      ];
+    }
+
+    return $element;
+  }
+
+  /**
+   * Hides cancel button.
+   *
+   * @param array $element
+   *   Form array structure.
+   */
+  public static function hideCancel($element) {
+    // @todo Name both buttons the same and simplify this logic.
+    if (isset($element['actions']['ief_add_cancel'])) {
+      $element['actions']['ief_add_cancel']['#access'] = FALSE;
+    }
+    elseif (isset($element['actions']['ief_reference_cancel'])) {
+      $element['actions']['ief_reference_cancel']['#access'] = FALSE;
+    }
+
+    return $element;
+  }
+
+  /**
+   * Builds remove form.
+   *
+   * @param array $form
+   *   Form array structure.
+   */
+  protected function buildRemoveForm(&$form) {
+    /** @var \Drupal\Core\Entity\EntityInterface $entity */
+    $entity = $form['#entity'];
+    $entity_id = $entity->id();
+    $entity_label = $this->inlineFormHandler->getEntityLabel($entity);
+    $labels = $this->getEntityTypeLabels();
+
+    if ($entity_label) {
+      $message = $this->t('Are you sure you want to remove %label?', ['%label' => $entity_label]);
+    }
+    else {
+      $message = $this->t('Are you sure you want to remove this %entity_type?', ['%entity_type' => $labels['singular']]);
+    }
+
+    $form['message'] = [
+      '#theme_wrappers' => ['container'],
+      '#markup' => $message,
+    ];
+
+    if (!empty($entity_id) && $this->getSetting('allow_existing') && $entity->access('delete')) {
+      $form['delete'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Delete this @type_singular from the system.', array('@type_singular' => $labels['singular'])),
+      ];
+    }
+
+    // Build a deta suffix that's appended to button #name keys for uniqueness.
+    $delta = $form['#ief_id'] . '-' . $form['#ief_row_delta'];
+
+    // Add actions to the form.
+    $form['actions'] = [
+      '#type' => 'container',
+      '#weight' => 100,
+    ];
+    $form['actions']['ief_remove_confirm'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Remove'),
+      '#name' => 'ief-remove-confirm-' . $delta,
+      '#limit_validation_errors' => [$form['#parents']],
+      '#ajax' => [
+        'callback' => 'inline_entity_form_get_element',
+        'wrapper' => 'inline-entity-form-' . $form['#ief_id'],
+      ],
+      '#allow_existing' => $this->getSetting('allow_existing'),
+      '#submit' => [[get_class($this), 'submitConfirmRemove']],
+      '#ief_row_delta' => $form['#ief_row_delta'],
+    ];
+    $form['actions']['ief_remove_cancel'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Cancel'),
+      '#name' => 'ief-remove-cancel-' . $delta,
+      '#limit_validation_errors' => [],
+      '#ajax' => [
+        'callback' => 'inline_entity_form_get_element',
+        'wrapper' => 'inline-entity-form-' . $form['#ief_id'],
+      ],
+      '#submit' => [[get_class($this), 'submitCloseRow']],
+      '#ief_row_delta' => $form['#ief_row_delta'],
+    ];
+  }
+
+  /**
+   * Button #submit callback: Closes a row form in the IEF widget.
+   *
+   * @param $form
+   *   The complete parent form.
+   * @param $form_state
+   *   The form state of the parent form.
+   *
+   * @see inline_entity_form_open_row_form().
+   */
+  public static function submitCloseRow($form, FormStateInterface $form_state) {
+    $element = inline_entity_form_get_element($form, $form_state);
+    $ief_id = $element['#ief_id'];
+    $delta = $form_state->getTriggeringElement()['#ief_row_delta'];
+
+    $form_state->setRebuild();
+    $form_state->set(['inline_entity_form', $ief_id, 'entities', $delta, 'form'], NULL);
+  }
+
+
+  /**
+   * Remove form submit callback.
+   *
+   * The row is identified by #ief_row_delta stored on the triggering
+   * element.
+   * This isn't an #element_validate callback to avoid processing the
+   * remove form when the main form is submitted.
+   *
+   * @param $form
+   *   The complete parent form.
+   * @param $form_state
+   *   The form state of the parent form.
+   */
+  public static function submitConfirmRemove($form, FormStateInterface $form_state) {
+    $element = inline_entity_form_get_element($form, $form_state);
+    $remove_button = $form_state->getTriggeringElement();
+    $delta = $remove_button['#ief_row_delta'];
+
+    /** @var \Drupal\Core\Field\FieldDefinitionInterface $instance */
+    $instance = $form_state->get(['inline_entity_form', $element['#ief_id'], 'instance']);
+
+    /** @var \Drupal\Core\Entity\EntityInterface $entity */
+    $entity = $element['entities'][$delta]['form']['#entity'];
+    $entity_id = $entity->id();
+
+    $form_values = NestedArray::getValue($form_state->getValues(), $element['entities'][$delta]['form']['#parents']);
+    $form_state->setRebuild();
+
+    $widget_state = $form_state->get(['inline_entity_form', $element['#ief_id']]);
+    // This entity hasn't been saved yet, we can just unlink it.
+    if (empty($entity_id) || ($remove_button['#allow_existing'] && empty($form_values['delete']))) {
+      unset($widget_state['entities'][$delta]);
+    }
+    else {
+      $widget_state['delete'][] = $entity;
+      unset($widget_state['entities'][$delta]);
+    }
+    $form_state->set(['inline_entity_form', $element['#ief_id']], $widget_state);
+  }
+
+  /**
+   * Determines bundle to be used when creating entity.
+   *
+   * @param FormStateInterface $form_state
+   *   Current form state.
+   *
+   * @return string
+   *   Bundle machine name.
+   *
+   * @TODO - Figure out if can be simplified.
+   */
+  protected function determineBundle(FormStateInterface $form_state) {
+    $ief_settings = $form_state->get(['inline_entity_form', $this->getIefId()]);
+    if (!empty($ief_settings['form settings']['bundle'])) {
+      return $ief_settings['form settings']['bundle'];
+    }
+    elseif (!empty($ief_settings['bundle'])) {
+      return $ief_settings['bundle'];
+    }
+    else {
+      $target_bundles = $this->getTargetBundles();
+      return reset($target_bundles);
+    }
+  }
+
+  /**
+   * Updates entity weights based on their weights in the widget.
+   */
+  public static function updateRowWeights($element, FormStateInterface $form_state, $form) {
+    $ief_id = $element['#ief_id'];
+
+    // Loop over the submitted delta values and update the weight of the entities
+    // in the form state.
+    foreach (Element::children($element['entities']) as $key) {
+      $form_state->set(['inline_entity_form', $ief_id, 'entities', $key, '_weight'], $element['entities'][$key]['delta']['#value']);
+    }
+  }
+
+  /**
+   * IEF widget #element_validate callback: Required field validation.
+   */
+  public static function requiredField($element, FormStateInterface $form_state, $form) {
+    $ief_id = $element['#ief_id'];
+    $children = $form_state->get(['inline_entity_form', $ief_id, 'entities']);
+    $has_children = !empty($children);
+    $form = $form_state->get(['inline_entity_form', $ief_id, 'form']);
+    $form_open = !empty($form);
+    // If the add new / add existing form is open, its validation / submission
+    // will do the job instead (either by preventing the parent form submission
+    // or by adding a new referenced entity).
+    if (!$has_children && !$form_open) {
+      /** @var \Drupal\Core\Field\FieldDefinitionInterface $instance */
+      $instance = $form_state->get(['inline_entity_form', $ief_id, 'instance']);
+      $form_state->setError($element, t('!name field is required.', array('!name' => $instance->getLabel())));
+    }
+  }
+
+  /**
+   * Button #submit callback: Closes a form in the IEF widget.
+   *
+   * @param $form
+   *   The complete parent form.
+   * @param $form_state
+   *   The form state of the parent form.
+   *
+   * @see inline_entity_form_open_form().
+   */
+  public static function closeForm($form, FormStateInterface $form_state) {
+    $element = inline_entity_form_get_element($form, $form_state);
+    $ief_id = $element['#ief_id'];
+
+    $form_state->setRebuild();
+    $form_state->set(['inline_entity_form', $ief_id, 'form'], NULL);
+  }
+
+  /**
+   * Add common submit callback functions and mark element as a IEF trigger.
+   *
+   * @param $element
+   */
+  public static function addSubmitCallbacks(&$element) {
+    $element['#submit'] = [
+      ['\Drupal\inline_entity_form\ElementSubmit', 'trigger'],
+      ['\Drupal\inline_entity_form\Plugin\Field\FieldWidget\InlineEntityFormComplex', 'closeForm'],
+    ];
+    $element['#ief_submit_trigger']  = TRUE;
+  }
+
+  /**
+   * Button #submit callback:  Closes all open child forms in the IEF widget.
+   *
+   * Used to ensure that forms in nested IEF widgets are properly closed
+   * when a parent IEF's form gets submitted or cancelled.
+   *
+   * @param $form
+   *   The IEF Form element.
+   * @param FormStateInterface $form_state
+   *   The form state of the parent form.
+   */
+  public static function closeChildForms($form, FormStateInterface &$form_state) {
+    $element = inline_entity_form_get_element($form, $form_state);
+    inline_entity_form_close_all_forms($element, $form_state);
+  }
+
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Plugin/Field/FieldWidget/InlineEntityFormSimple.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Plugin/Field/FieldWidget/InlineEntityFormSimple.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Drupal\inline_entity_form\Plugin\Field\FieldWidget;
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+
+/**
+ * Simple inline widget.
+ *
+ * @FieldWidget(
+ *   id = "inline_entity_form_simple",
+ *   label = @Translation("Inline entity form - Simple"),
+ *   field_types = {
+ *     "entity_reference"
+ *   },
+ *   multiple_values = false
+ * )
+ */
+class InlineEntityFormSimple extends InlineEntityFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    // Trick inline_entity_form_form_alter() into attaching the handlers,
+    // WidgetSubmit will be needed once extractFormValues fills the $form_state.
+    $parents = array_merge($element['#field_parents'], [$items->getName()]);
+    $ief_id = sha1(implode('-', $parents));
+    $form_state->set(['inline_entity_form', $ief_id], []);
+
+    $element['#type'] = 'fieldset';
+    $item = $items->get($delta);
+    if ($item->target_id && !$item->entity) {
+      $element['warning']['#markup'] = $this->t('Unable to load the referenced entity.');
+      return $element;
+    }
+    $entity = $item->entity;
+    $op = $entity ? 'edit' : 'add';
+    $language = $items->getParent()->getValue()->language()->getId();
+    $parents = array_merge($element['#field_parents'], [
+      $items->getName(),
+      $delta,
+      'inline_entity_form'
+    ]);
+    $bundle = reset($this->getFieldSetting('handler_settings')['target_bundles']);
+    $element['inline_entity_form'] = $this->getInlineEntityForm($op, $bundle, $language, $delta, $parents, $entity);
+
+    if ($op == 'edit') {
+      /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+      if (!$entity->access('update')) {
+        // The user isn't allowed to edit the entity, but still needs to see
+        // it, to be able to reorder values.
+        $element['entity_label'] = [
+          '#type' => 'markup',
+          '#markup' => $entity->label(),
+        ];
+        // Hide the inline form. getInlineEntityForm() still needed to be
+        // called because otherwise the field re-ordering doesn't work.
+        $element['inline_entity_form']['#access'] = FALSE;
+      }
+    }
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function formMultipleElements(FieldItemListInterface $items, array &$form, FormStateInterface $form_state) {
+    $element = parent::formMultipleElements($items, $form, $form_state);
+
+    // If we're using ulimited cardinality we don't display one empty item. Form
+    // validation will kick in if left empty which esentially means people won't
+    // be able to submit w/o creating another entity.
+    if (!$form_state->isSubmitted() && $element['#cardinality'] == FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED && $element['#max_delta'] > 0) {
+      $max = $element['#max_delta'];
+      unset($element[$max]);
+      $element['#max_delta'] = $max - 1;
+      $items->removeItem($max);
+      // Decrement the items count.
+      $field_name = $element['#field_name'];
+      $parents = $element[0]['#field_parents'];
+      $field_state = static::getWidgetState($parents, $field_name, $form_state);
+      $field_state['items_count']--;
+      static::setWidgetState($parents, $field_name, $form_state, $field_state);
+    }
+
+    // Remove add options if the user cannot add new entities.
+    if (!$this->canAddNew()) {
+      if (isset($element['add_more'])) {
+        unset($element['add_more']);
+      }
+      foreach (Element::children($element) as $delta) {
+        if (isset($element[$delta]['inline_entity_form'])) {
+          if ($element[$delta]['inline_entity_form']['#op'] == 'add') {
+            unset($element[$delta]);
+          }
+        }
+      }
+    }
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function extractFormValues(FieldItemListInterface $items, array $form, FormStateInterface $form_state) {
+    if ($this->isDefaultValueWidget($form_state)) {
+      $items->filterEmptyItems();
+      return;
+    }
+
+    $field_name = $this->fieldDefinition->getName();
+    $parents = array_merge($form['#parents'], [$field_name]);
+    $submitted_values = $form_state->getValue($parents);
+    $values = [];
+    foreach ($items as $delta => $value) {
+      $element = NestedArray::getValue($form, [$field_name, 'widget', $delta]);
+      /** @var \Drupal\Core\Entity\EntityInterface $entity */
+      $entity = $element['inline_entity_form']['#entity'];
+      $weight = isset($submitted_values[$delta]['_weight']) ? $submitted_values[$delta]['_weight'] : 0;
+      $values[$weight] = ['entity' => $entity];
+    }
+
+    // Sort items base on weights.
+    ksort($values);
+    $values = array_values($values);
+
+    // Let the widget massage the submitted values.
+    $values = $this->massageFormValues($values, $form, $form_state);
+
+    // Assign the values and remove the empty ones.
+    $items->setValue($values);
+    $items->filterEmptyItems();
+
+    // Populate the IEF form state with $items so that WidgetSubmit can
+    // perform the necessary saves.
+    $ief_id = sha1(implode('-', $parents));
+    $widget_state = [
+      'instance' => $this->fieldDefinition,
+      'delete' => [],
+      'entities' => [],
+    ];
+    foreach ($items as $delta => $value) {
+      $widget_state['entities'][$delta] = [
+        'entity' => $value->entity,
+        'needs_save' => TRUE,
+      ];
+    }
+    $form_state->set(['inline_entity_form', $ief_id], $widget_state);
+
+    // Put delta mapping in $form_state, so that flagErrors() can use it.
+    $field_name = $this->fieldDefinition->getName();
+    $field_state = WidgetBase::getWidgetState($form['#parents'], $field_name, $form_state);
+    foreach ($items as $delta => $item) {
+      $field_state['original_deltas'][$delta] = isset($item->_original_delta) ? $item->_original_delta : $delta;
+      unset($item->_original_delta, $item->_weight);
+    }
+
+    WidgetBase::setWidgetState($form['#parents'], $field_name, $form_state, $field_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function isApplicable(FieldDefinitionInterface $field_definition) {
+    if (!$field_definition->isRequired()) {
+      return FALSE;
+    }
+
+    $handler_settings = $field_definition->getSettings()['handler_settings'];
+    // Entity types without bundles will throw notices on next condition so let's
+    // stop before they do. We should support this kind of entities too. See
+    // https://www.drupal.org/node/2569193 and remove this check once that issue
+    // lands.
+    if (empty($handler_settings['target_bundles'])) {
+      return FALSE;
+    }
+
+    if (count($handler_settings['target_bundles']) != 1) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Tests/ComplexSimpleWidgetTest.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Tests/ComplexSimpleWidgetTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\inline_entity_form\Tests;
+
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+
+/**
+ * IEF complex field widget containing an IEF simple field widget tests.
+ *
+ * @group inline_entity_form
+ */
+class ComplexSimpleWidgetTest extends InlineEntityFormTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'inline_entity_form_test',
+    'field',
+    'field_ui',
+  ];
+
+  protected function setUp() {
+    parent::setUp();
+
+    $this->user = $this->createUser([
+      'create ief_complex_simple content',
+      'create ief_simple_single content',
+      'create ief_test_custom content',
+      'view own unpublished content',
+    ]);
+    $this->drupalLogin($this->user);
+    $this->fieldConfigStorage = $this->container->get('entity_type.manager')->getStorage('field_config');
+  }
+
+  /**
+   * Test a Simple IEF widget inside of Complex IEF widget.
+   */
+  public function testSimpleInComplex() {
+    $outer_required_options = [
+      TRUE,
+      FALSE,
+    ];
+    $cardinality_options = [
+      1 => 1,
+      2 => 2,
+      FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED => 3,
+    ];
+    /** @var \Drupal\field\FieldStorageConfigInterface $field_storage */
+    $field_storage = $this->fieldStorageConfigStorage->load('node.ief_complex_outer');
+    /** @var \Drupal\Core\Field\FieldConfigInterface $field_config */
+    $field_config = $this->fieldConfigStorage->load('node.ief_complex_simple.ief_complex_outer');
+    foreach ($outer_required_options as $outer_required_option) {
+      $edit = [];
+      $field_config->setRequired($outer_required_option);
+      $field_config->save();
+      foreach ($cardinality_options as $cardinality => $limit) {
+        $field_storage->setCardinality($cardinality);
+        $field_storage->save();
+
+        $this->drupalGet('node/add/ief_complex_simple');
+        $outer_title_field = 'ief_complex_outer[form][inline_entity_form][title][0][value]';
+        $inner_title_field = 'ief_complex_outer[form][inline_entity_form][single][0][inline_entity_form][title][0][value]';
+        if (!$outer_required_option) {
+          $this->assertText('Complex Outer', 'Complex Inline entity field widget title found.');
+          // Field should not be available before ajax submit.
+          $this->assertNoFieldByName($outer_title_field, NULL);
+          $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @value="Add new node" and @data-drupal-selector="edit-ief-complex-outer-actions-ief-add"]'));
+        }
+        $this->assertFieldByName($outer_title_field, NULL);
+        // Simple widget is required so should always show up. No need for add submit.
+        $this->assertFieldByName($inner_title_field, NULL);
+
+        $edit[$outer_title_field] = $outer_title = $this->randomMachineName(8);
+        $edit[$inner_title_field] = $inner_title = $this->randomMachineName(8);
+        $create_outer_button_selector = '//input[@type="submit" and @value="Create node" and @data-drupal-selector="edit-ief-complex-outer-form-inline-entity-form-actions-ief-add-save"]';
+        $this->drupalPostAjaxForm(NULL, $edit, $this->getButtonName($create_outer_button_selector));
+        // After ajax submit the ief title fields should be gone.
+        $this->assertNoFieldByName($outer_title_field, NULL);
+        $this->assertNoFieldByName($inner_title_field, NULL);
+        $this->assertEqual('', $this->getButtonName($create_outer_button_selector), 'Create node button not found after Ajax submit.');
+
+        // The nodes should not actually be saved at this point
+        $this->assertNoNodeByTitle($outer_title, 'Outer node was not created when widget submitted.');
+        $this->assertNoNodeByTitle($inner_title, 'Inner node was not created when widget submitted.');
+
+        $host_title = $this->randomMachineName(8);
+        $edit = ['title[0][value]' => $host_title];
+        $this->drupalPostForm(NULL, $edit, t('Save'));
+        $this->assertText("$host_title has been created.");
+        $this->assertText($outer_title);
+
+        // Check the nodes were created correctly.
+        $host_node = $this->drupalGetNodeByTitle($host_title);
+        if ($this->assertNotNull($host_node->ief_complex_outer->entity, 'Outer node was created.')) {
+          $outer_node = $host_node->ief_complex_outer->entity;
+          $this->assertEqual($outer_title, $outer_node->label(), "Outer node's title looks correct.");
+          $this->assertEqual('ief_simple_single', $outer_node->bundle(), "Outer node's type looks correct.");
+          if ($this->assertNotNull($outer_node->single->entity, 'Inner node was created')) {
+            $inner_node = $outer_node->single->entity;
+            $this->assertEqual($inner_title, $inner_node->label(), "Inner node's title looks correct.");
+            $this->assertEqual('ief_test_custom', $inner_node->bundle(), "Inner node's type looks correct.");
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Tests/ComplexWidgetWebTest.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Tests/ComplexWidgetWebTest.php
@@ -1,0 +1,742 @@
+<?php
+
+namespace Drupal\inline_entity_form\Tests;
+
+use Drupal\node\Entity\Node;
+
+/**
+ * IEF complex field widget tests.
+ *
+ * @group inline_entity_form
+ */
+class ComplexWidgetWebTest extends InlineEntityFormTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'inline_entity_form_test',
+    'field',
+    'field_ui',
+  ];
+
+  /**
+   * URL to add new content.
+   *
+   * @var string
+   */
+  protected $formContentAddUrl;
+
+  /**
+   * Entity form display storage.
+   *
+   * @var \Drupal\Core\Config\Entity\ConfigEntityStorageInterface
+   */
+  protected $entityFormDisplayStorage;
+
+  /**
+   * Prepares environment for
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->user = $this->createUser([
+      'create ief_reference_type content',
+      'edit any ief_reference_type content',
+      'delete any ief_reference_type content',
+      'create ief_test_complex content',
+      'edit any ief_test_complex content',
+      'delete any ief_test_complex content',
+      'edit any ief_test_nested1 content',
+      'edit any ief_test_nested2 content',
+      'edit any ief_test_nested3 content',
+      'view own unpublished content',
+      'administer content types',
+    ]);
+    $this->drupalLogin($this->user);
+
+    $this->formContentAddUrl = 'node/add/ief_test_complex';
+    $this->entityFormDisplayStorage = $this->container->get('entity_type.manager')->getStorage('entity_form_display');
+  }
+
+  /**
+   * Tests if form behaves correctly when field is empty.
+   */
+  public function testEmptyFieldIEF() {
+    // Don't allow addition of existing nodes.
+    $this->setAllowExisting(FALSE);
+    $this->drupalGet($this->formContentAddUrl);
+
+    $this->assertFieldByName('multi[form][inline_entity_form][title][0][value]', NULL, 'Title field on inline form exists.');
+    $this->assertFieldByName('multi[form][inline_entity_form][first_name][0][value]', NULL, 'First name field on inline form exists.');
+    $this->assertFieldByName('multi[form][inline_entity_form][last_name][0][value]', NULL, 'Last name field on inline form exists.');
+    $this->assertFieldByXpath('//input[@type="submit" and @value="Create node"]', NULL, 'Found "Create node" submit button');
+
+    // Allow addition of existing nodes.
+    $this->setAllowExisting(TRUE);
+    $this->drupalGet($this->formContentAddUrl);
+
+    $this->assertNoFieldByName('multi[form][inline_entity_form][title][0][value]', NULL, 'Title field does not appear.');
+    $this->assertNoFieldByName('multi[form][inline_entity_form][first_name][0][value]', NULL, 'First name field does not appear.');
+    $this->assertNoFieldByName('multi[form][inline_entity_form][last_name][0][value]', NULL, 'Last name field does not appear.');
+    $this->assertFieldByXpath('//input[@type="submit" and @value="Add new node"]', NULL, 'Found "Add new node" submit button');
+    $this->assertFieldByXpath('//input[@type="submit" and @value="Add existing node"]', NULL, 'Found "Add existing node" submit button');
+
+    // Now submit 'Add new node' button.
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @value="Add new node" and @data-drupal-selector="edit-multi-actions-ief-add"]'));
+
+    $this->assertFieldByName('multi[form][inline_entity_form][title][0][value]', NULL, 'Title field on inline form exists.');
+    $this->assertFieldByName('multi[form][inline_entity_form][first_name][0][value]', NULL, 'First name field on inline form exists.');
+    $this->assertFieldByName('multi[form][inline_entity_form][last_name][0][value]', NULL, 'Second name field on inline form exists.');
+    $this->assertFieldByXpath('//input[@type="submit" and @value="Create node"]', NULL, 'Found "Create node" submit button');
+    $this->assertFieldByXpath('//input[@type="submit" and @value="Cancel"]', NULL, 'Found "Cancel" submit button');
+
+    // Now submit 'Add Existing node' button.
+    $this->drupalGet($this->formContentAddUrl);
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @value="Add existing node" and @data-drupal-selector="edit-multi-actions-ief-add-existing"]'));
+
+    $this->assertFieldByName('multi[form][entity_id]', NULL, 'Existing entity reference autocomplete field found.');
+    $this->assertFieldByXpath('//input[@type="submit" and @value="Add node"]', NULL, 'Found "Add node" submit button');
+    $this->assertFieldByXpath('//input[@type="submit" and @value="Cancel"]', NULL, 'Found "Cancel" submit button');
+  }
+
+  /**
+   * Tests creation of entities.
+   */
+  public function testEntityCreation() {
+    // Allow addition of existing nodes.
+    $this->setAllowExisting(TRUE);
+    $this->drupalGet($this->formContentAddUrl);
+
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @value="Add new node" and @data-drupal-selector="edit-multi-actions-ief-add"]'));
+    $this->assertResponse(200, 'Opening new inline form was successful.');
+
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @value="Create node" and @data-drupal-selector="edit-multi-form-inline-entity-form-actions-ief-add-save"]'));
+    $this->assertResponse(200, 'Submitting empty form was successful.');
+    $this->assertText('First name field is required.', 'Validation failed for empty "First name" field.');
+    $this->assertText('Last name field is required.', 'Validation failed for empty "Last name" field.');
+    $this->assertText('Title field is required.', 'Validation failed for empty "Title" field.');
+
+    // Create ief_reference_type node in IEF.
+    $this->drupalGet($this->formContentAddUrl);
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @value="Add new node" and @data-drupal-selector="edit-multi-actions-ief-add"]'));
+    $this->assertResponse(200, 'Opening new inline form was successful.');
+
+    $edit = [
+      'multi[form][inline_entity_form][title][0][value]' => 'Some reference',
+      'multi[form][inline_entity_form][first_name][0][value]' => 'John',
+      'multi[form][inline_entity_form][last_name][0][value]' => 'Doe',
+    ];
+    $this->drupalPostAjaxForm(NULL, $edit, $this->getButtonName('//input[@type="submit" and @value="Create node" and @data-drupal-selector="edit-multi-form-inline-entity-form-actions-ief-add-save"]'));
+    $this->assertResponse(200, 'Creating node via inline form was successful.');
+
+    // Tests if correct fields appear in the table.
+    $this->assertTrue((bool) $this->xpath('//td[@class="inline-entity-form-node-label" and contains(.,"Some reference")]'), 'Node title field appears in the table');
+    $this->assertTrue((bool) $this->xpath('//td[@class="inline-entity-form-node-status" and ./div[contains(.,"Published")]]'), 'Node status field appears in the table');
+
+    // Tests if edit and remove buttons appear.
+    $this->assertTrue((bool) $this->xpath('//input[@type="submit" and @value="Edit"]'), 'Edit button appears in the table.');
+    $this->assertTrue((bool) $this->xpath('//input[@type="submit" and @value="Remove"]'), 'Remove button appears in the table.');
+
+    // Test edit functionality.
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @value="Edit"]'));
+    $edit = [
+      'multi[form][inline_entity_form][entities][0][form][title][0][value]' => 'Some changed reference',
+    ];
+    $this->drupalPostAjaxForm(NULL, $edit, $this->getButtonName('//input[@type="submit" and @value="Update node"]'));
+    $this->assertTrue((bool) $this->xpath('//td[@class="inline-entity-form-node-label" and contains(.,"Some changed reference")]'), 'Node title field appears in the table');
+    $this->assertTrue((bool) $this->xpath('//td[@class="inline-entity-form-node-status" and ./div[contains(.,"Published")]]'), 'Node status field appears in the table');
+
+    // Make sure unrelated AJAX submit doesn't save the referenced entity.
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @value="Upload"]'));
+    $node = $this->drupalGetNodeByTitle('Some changed reference');
+    $this->assertFalse($node, 'Referenced node was not saved during unrelated AJAX submit.');
+
+    // Create ief_test_complex node.
+    $edit = ['title[0][value]' => 'Some title'];
+    $this->drupalPostForm(NULL, $edit, t('Save'));
+    $this->assertResponse(200, 'Saving parent entity was successful.');
+
+    // Checks values of created entities.
+    $node = $this->drupalGetNodeByTitle('Some changed reference');
+    $this->assertTrue($node, 'Created ief_reference_type node ' . $node->label());
+    $this->assertTrue($node->get('first_name')->value == 'John', 'First name in reference node set to John');
+    $this->assertTrue($node->get('last_name')->value == 'Doe', 'Last name in reference node set to Doe');
+
+    $parent_node = $this->drupalGetNodeByTitle('Some title');
+    $this->assertTrue($parent_node, 'Created ief_test_complex node ' . $parent_node->label());
+    $this->assertTrue($parent_node->multi->target_id == $node->id(), 'Refererence node id set to ' . $node->id());
+  }
+
+  /**
+   * Tests the entity creation with different bundles nested in each other.
+   *
+   * ief_test_nested1 -> ief_test_nested2 -> ief_test_nested3
+   */
+  public function testNestedEntityCreationWithDifferentBundlesAjaxSubmit() {
+    $required_possibilities = [
+      FALSE,
+      TRUE,
+    ];
+    foreach ($required_possibilities as $required) {
+      $this->setupNestedComplexForm($required);
+
+
+      $nested3_title = 'nested3 title steps ' . ($required ? 'required' : 'not required');
+      $nested2_title = 'nested2 title steps ' . ($required ? 'required' : 'not required');
+      $nested1_title = 'nested1 title steps ' . ($required ? 'required' : 'not required');
+      $edit = [
+        'test_ref_nested1[form][inline_entity_form][test_ref_nested2][form][inline_entity_form][title][0][value]' => $nested3_title,
+      ];
+      $this->drupalPostAjaxForm(NULL, $edit, $this->getButtonName('//input[@type="submit" and @value="Create node 3"]'));
+      $this->assertText($nested3_title, 'Title of second nested node found.');
+      $this->assertNoNodeByTitle($nested3_title, 'Second nested entity is not saved yet.');
+
+      $edit = [
+        'test_ref_nested1[form][inline_entity_form][title][0][value]' => $nested2_title,
+      ];
+      $this->drupalPostAjaxForm(NULL, $edit, $this->getButtonName('//input[@type="submit" and @value="Create node 2"]'));
+      $this->assertText($nested2_title, 'Title of first nested node found.');
+      $this->assertNoNodeByTitle($nested2_title, 'First nested entity is not saved yet.');
+
+      $edit = [
+        'title[0][value]' => $nested1_title,
+      ];
+      $this->drupalPostForm(NULL, $edit, t('Save'));
+      $this->checkNestedNodes($nested1_title, $nested2_title, $nested3_title);
+    }
+  }
+
+  /**
+   * Checks that nested IEF entity references can be edit and saved.
+   *
+   * @param \Drupal\node\Entity\Node $node
+   *  Top level node of type ief_test_nested1 to check.
+   * @param bool $ajax_submit
+   *  Whether IEF form widgets should be submitted via AJax or left open.
+   *
+   */
+  protected function checkNestedEntityEditing(Node $node, $ajax_submit = TRUE) {
+    $this->drupalGet("node/{$node->id()}/edit");
+    /** @var \Drupal\node\Entity\Node $level_1_node */
+    $level_1_node = $node->test_ref_nested1->entity;
+    /** @var \Drupal\node\Entity\Node $level_2_node */
+    $level_2_node = $node->test_ref_nested1->entity->test_ref_nested2->entity;
+    $level_2_node_update_title = $level_2_node->getTitle() . ' - updated';
+    //edit-test-ref-nested1-entities-0-actions-ief-entity-edit
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @data-drupal-selector="edit-test-ref-nested1-entities-0-actions-ief-entity-edit"]'));
+    //edit-test-ref-nested1-form-inline-entity-form-entities-0-form-test-ref-nested2-entities-0-actions-ief-entity-edit
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @data-drupal-selector="edit-test-ref-nested1-form-inline-entity-form-entities-0-form-test-ref-nested2-entities-0-actions-ief-entity-edit"]'));
+    $edit['test_ref_nested1[form][inline_entity_form][entities][0][form][test_ref_nested2][form][inline_entity_form][entities][0][form][title][0][value]'] = $level_2_node_update_title;
+    if ($ajax_submit) {
+      // Close IEF Forms with AJAX posts
+      //edit-test-ref-nested1-form-inline-entity-form-entities-0-form-test-ref-nested2-form-inline-entity-form-entities-0-form-actions-ief-edit-save
+      $this->drupalPostAjaxForm(NULL, $edit, $this->getButtonName('//input[@type="submit" and @data-drupal-selector="edit-test-ref-nested1-form-inline-entity-form-entities-0-form-test-ref-nested2-form-inline-entity-form-entities-0-form-actions-ief-edit-save"]'));
+      $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @data-drupal-selector="edit-test-ref-nested1-form-inline-entity-form-entities-0-form-actions-ief-edit-save"]'));
+      $this->drupalPostForm(NULL, [], t('Save'));
+    }
+    else {
+      $this->drupalPostForm(NULL, $edit, t('Save'));
+    }
+    $this->nodeStorage->resetCache([$level_2_node->id()]);
+    $level_2_node = $this->nodeStorage->load($level_2_node->id());
+    $this->assertEqual($level_2_node_update_title, $level_2_node->getTitle());
+  }
+
+  /**
+   * Tests the entity creation with different bundles nested in each other.
+   *
+   * ief_test_nested1 -> ief_test_nested2 -> ief_test_nested3
+   */
+  public function testNestedEntityCreationWithDifferentBundlesNoAjaxSubmit() {
+    $required_possibilities = [
+      FALSE,
+      TRUE,
+    ];
+
+    foreach ($required_possibilities as $required) {
+      $this->setupNestedComplexForm($required);
+
+      $nested3_title = 'nested3 title single ' . ($required ? 'required' : 'not required');
+      $nested2_title = 'nested2 title single ' . ($required ? 'required' : 'not required');
+      $nested1_title = 'nested1 title single ' . ($required ? 'required' : 'not required');
+
+      $edit = [
+        'title[0][value]' => $nested1_title,
+        'test_ref_nested1[form][inline_entity_form][title][0][value]' => $nested2_title,
+        'test_ref_nested1[form][inline_entity_form][test_ref_nested2][form][inline_entity_form][title][0][value]' => $nested3_title,
+      ];
+      $this->drupalPostForm(NULL, $edit, t('Save'));
+      $this->checkNestedNodes($nested1_title, $nested2_title, $nested3_title);
+    }
+  }
+
+  /**
+   * Tests if editing and removing entities work.
+   */
+  public function testEntityEditingAndRemoving() {
+    // Allow addition of existing nodes.
+    $this->setAllowExisting(TRUE);
+
+    // Create three ief_reference_type entities.
+    $referenceNodes = $this->createReferenceContent(3);
+    $this->drupalCreateNode([
+      'type' => 'ief_test_complex',
+      'title' => 'Some title',
+      'multi' => array_values($referenceNodes),
+    ]);
+    /** @var \Drupal\node\NodeInterface $node */
+    $parent_node = $this->drupalGetNodeByTitle('Some title');
+
+    // Edit the second entity.
+    $this->drupalGet('node/'. $parent_node->id() .'/edit');
+    $cell = $this->xpath('//table[@id="ief-entity-table-edit-multi-entities"]/tbody/tr[@class="ief-row-entity draggable even"]/td[@class="inline-entity-form-node-label"]');
+    $title = (string) $cell[0];
+
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @id="edit-multi-entities-1-actions-ief-entity-edit"]'));
+    $this->assertResponse(200, 'Opening inline edit form was successful.');
+
+    $edit = [
+      'multi[form][inline_entity_form][entities][1][form][first_name][0][value]' => 'John',
+      'multi[form][inline_entity_form][entities][1][form][last_name][0][value]' => 'Doe',
+    ];
+    $this->drupalPostAjaxForm(NULL, $edit, $this->getButtonName('//input[@type="submit" and @data-drupal-selector="edit-multi-form-inline-entity-form-entities-1-form-actions-ief-edit-save"]'));
+    $this->assertResponse(200, 'Saving inline edit form was successful.');
+
+    // Save the ief_test_complex node.
+    $this->drupalPostForm(NULL, [], t('Save'));
+    $this->assertResponse(200, 'Saving parent entity was successful.');
+
+    // Checks values of changed entities.
+    $node = $this->drupalGetNodeByTitle($title, TRUE);
+    $this->assertTrue($node->first_name->value == 'John', 'First name in reference node changed to John');
+    $this->assertTrue($node->last_name->value == 'Doe', 'Last name in reference node changed to Doe');
+
+    // Delete the second entity.
+    $this->drupalGet('node/'. $parent_node->id() .'/edit');
+    $cell = $this->xpath('//table[@id="ief-entity-table-edit-multi-entities"]/tbody/tr[@class="ief-row-entity draggable even"]/td[@class="inline-entity-form-node-label"]');
+    $title = (string) $cell[0];
+
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @id="edit-multi-entities-1-actions-ief-entity-remove"]'));
+    $this->assertResponse(200, 'Opening inline remove confirm form was successful.');
+    $this->assertText('Are you sure you want to remove', 'Remove warning message is displayed.');
+
+    $this->drupalPostAjaxForm(NULL, ['multi[form][entities][1][form][delete]' => TRUE], $this->getButtonName('//input[@type="submit" and @data-drupal-selector="edit-multi-form-entities-1-form-actions-ief-remove-confirm"]'));
+    $this->assertResponse(200, 'Removing inline entity was successful.');
+    $this->assertNoText($title, 'Deleted inline entity is not present on the page.');
+
+    // Save the ief_test_complex node.
+    $this->drupalPostForm(NULL, [], t('Save'));
+    $this->assertResponse(200, 'Saving parent node was successful.');
+
+    $deleted_node = $this->drupalGetNodeByTitle($title);
+    $this->assertTrue(empty($deleted_node), 'The inline entity was deleted from the site.');
+
+    // Checks that entity does nor appear in IEF.
+    $this->drupalGet('node/'. $parent_node->id() .'/edit');
+    $this->assertNoText($title, 'Deleted inline entity is not present on the page after saving parent.');
+
+    // Delete the third entity reference only, don't delete the node. The third
+    // entity now is second referenced entity because the second one was deleted
+    // in previous step.
+    $this->drupalGet('node/'. $parent_node->id() .'/edit');
+    $cell = $this->xpath('//table[@id="ief-entity-table-edit-multi-entities"]/tbody/tr[@class="ief-row-entity draggable even"]/td[@class="inline-entity-form-node-label"]');
+    $title = (string) $cell[0];
+
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @id="edit-multi-entities-1-actions-ief-entity-remove"]'));
+    $this->assertResponse(200, 'Opening inline remove confirm form was successful.');
+
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @data-drupal-selector="edit-multi-form-entities-1-form-actions-ief-remove-confirm"]'));
+    $this->assertResponse(200, 'Removing inline entity was successful.');
+
+    // Save the ief_test_complex node.
+    $this->drupalPostForm(NULL, [], t('Save'));
+    $this->assertResponse(200, 'Saving parent node was successful.');
+
+    // Checks that entity does nor appear in IEF.
+    $this->drupalGet('node/'. $parent_node->id() . '/edit');
+    $this->assertNoText($title, 'Deleted inline entity is not present on the page after saving parent.');
+
+    // Checks that entity is not deleted.
+    $node = $this->drupalGetNodeByTitle($title, TRUE);
+    $this->assertTrue($node, 'Reference node not deleted');
+  }
+
+  /**
+   * Tests if referencing existing entities work.
+   */
+  public function testReferencingExistingEntities() {
+    // Allow addition of existing nodes.
+    $this->setAllowExisting(TRUE);
+
+    // Create three ief_reference_type entities.
+    $referenceNodes = $this->createReferenceContent(3);
+
+    // Create a node for every bundle available.
+    $bundle_nodes = $this->createNodeForEveryBundle();
+
+    // Create ief_test_complex node with first ief_reference_type node and first
+    // node from bundle nodes.
+    $this->drupalCreateNode([
+      'type' => 'ief_test_complex',
+      'title' => 'Some title',
+      'multi' => [1],
+      'all_bundles' => key($bundle_nodes),
+    ]);
+    // Remove first node since we already added it.
+    unset($bundle_nodes[key($bundle_nodes)]);
+
+    $parent_node = $this->drupalGetNodeByTitle('Some title', TRUE);
+
+    // Add remaining existing reference nodes.
+    $this->drupalGet('node/' . $parent_node->id() . '/edit');
+    for ($i = 2; $i <= 3; $i++) {
+      $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @value="Add existing node" and @data-drupal-selector="edit-multi-actions-ief-add-existing"]'));
+      $this->assertResponse(200, 'Opening reference form was successful.');
+      $title = 'Some reference ' . $i;
+      $edit = [
+        'multi[form][entity_id]' => $title . ' (' . $referenceNodes[$title] . ')',
+      ];
+      $this->drupalPostAjaxForm(NULL, $edit, $this->getButtonName('//input[@type="submit" and @data-drupal-selector="edit-multi-form-actions-ief-reference-save"]'));
+      $this->assertResponse(200, 'Adding new referenced entity was successful.');
+    }
+    // Add all remaining nodes from all bundles.
+    foreach ($bundle_nodes as $id => $title) {
+      $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @value="Add existing node" and @data-drupal-selector="edit-all-bundles-actions-ief-add-existing"]'));
+      $this->assertResponse(200, 'Opening reference form was successful.');
+      $edit = [
+        'all_bundles[form][entity_id]' => $title . ' (' . $id . ')',
+      ];
+      $this->drupalPostAjaxForm(NULL, $edit, $this->getButtonName('//input[@type="submit" and @data-drupal-selector="edit-all-bundles-form-actions-ief-reference-save"]'));
+      $this->assertResponse(200, 'Adding new referenced entity was successful.');
+    }
+    // Save the node.
+    $this->drupalPostForm(NULL, [], t('Save'));
+    $this->assertResponse(200, 'Saving parent for was successful.');
+
+    // Check if entities are referenced.
+    $this->drupalGet('node/'. $parent_node->id() .'/edit');
+    for ($i = 2; $i <= 3; $i++) {
+      $cell = $this->xpath('//table[@id="ief-entity-table-edit-multi-entities"]/tbody/tr[' . $i . ']/td[@class="inline-entity-form-node-label"]');
+      $this->assertTrue($cell[0] == 'Some reference ' . $i, 'Found reference node title "Some reference ' . $i .'" in the IEF table.');
+    }
+    // Check if all remaining nodes from all bundles are referenced.
+    $count = 2;
+    foreach ($bundle_nodes as $id => $title) {
+      $cell = $this->xpath('//table[@id="ief-entity-table-edit-all-bundles-entities"]/tbody/tr[' . $count . ']/td[@class="inline-entity-form-node-label"]');
+      $this->assertTrue($cell[0] == $title, 'Found reference node title "' . $title . '" in the IEF table.');
+      $count++;
+    }
+  }
+
+  /**
+   * Test if invalid values get correct validation messages in reference existing entity form.
+   *
+   * Also checks if existing entity reference form can be canceled.
+   */
+  public function testReferenceExistingValidation() {
+    $this->setAllowExisting(TRUE);
+
+    $this->drupalGet('node/add/ief_test_complex');
+    $this->checkExistingValidationExpectation('', 'Node field is required.');
+    $this->checkExistingValidationExpectation('Fake Title', "There are no entities matching \"Fake Title\"");
+    // Check adding nodes that cannot be referenced by this field.
+    $bundle_nodes = $this->createNodeForEveryBundle();
+    foreach ($bundle_nodes as $id => $title) {
+      $node = $this->nodeStorage->load($id);
+      if ($node->bundle() != 'ief_reference_type') {
+        $this->checkExistingValidationExpectation("$title ($id)", "The referenced entity (node: $id) does not exist.");
+      }
+    }
+
+    $nodes = $this->createReferenceContent(2);
+    foreach ($nodes as $title => $id) {
+      $this->openMultiExistingForm();
+      $edit = [
+        'multi[form][entity_id]' => "$title ($id)",
+      ];
+      // Add a node successfully.
+      $this->drupalPostAjaxForm(NULL, $edit, $this->getButtonName('//input[@type="submit" and @data-drupal-selector="edit-multi-form-actions-ief-reference-save"]'));
+      $this->assertNoFieldByName('multi[form][entity_id]', NULL, 'Existing entity reference autocomplete field removed.');
+      // Try to add the same node again.
+      $this->checkExistingValidationExpectation("$title ($id)", 'The selected node has already been added.');
+    }
+  }
+
+  /**
+   * Tests if a referenced content can be edited while the referenced content is
+   * newer than the referencing parent node.
+   */
+  public function testEditedInlineEntityValidation() {
+    $this->setAllowExisting(TRUE);
+
+    // Create referenced content.
+    $referenced_nodes = $this->createReferenceContent(1);
+
+    // Create first referencing node.
+    $this->drupalCreateNode([
+      'type' => 'ief_test_complex',
+      'title' => 'First referencing node',
+      'multi' => array_values($referenced_nodes),
+    ]);
+    $first_node = $this->drupalGetNodeByTitle('First referencing node');
+
+    // Create second referencing node.
+    $this->drupalCreateNode([
+      'type' => 'ief_test_complex',
+      'title' => 'Second referencing node',
+      'multi' => array_values($referenced_nodes),
+    ]);
+    $second_node = $this->drupalGetNodeByTitle('Second referencing node');
+
+    // Edit referenced content in first node.
+    $this->drupalGet('node/' . $first_node->id() . '/edit');
+
+    // Edit referenced node.
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @value="Edit" and @data-drupal-selector="edit-multi-entities-0-actions-ief-entity-edit"]'));
+    $edit = [
+      'multi[form][inline_entity_form][entities][0][form][title][0][value]' => 'Some reference updated',
+    ];
+    $this->drupalPostAjaxForm(NULL, $edit, $this->getButtonName('//input[@type="submit" and @value="Update node" and @data-drupal-selector="edit-multi-form-inline-entity-form-entities-0-form-actions-ief-edit-save"]'));
+
+    // Save the first node after editing the reference.
+    $edit = ['title[0][value]' => 'First node updated'];
+    $this->drupalPostForm(NULL, $edit, t('Save'));
+
+    // The changed value of the referenced content is now newer than the
+    // changed value of the second node.
+
+    // Edit referenced content in second node.
+    $this->drupalGet('node/' . $second_node->id() . '/edit');
+
+    // Edit referenced node.
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @value="Edit" and @data-drupal-selector="edit-multi-entities-0-actions-ief-entity-edit"]'));
+    $edit = [
+      'multi[form][inline_entity_form][entities][0][form][title][0][value]' => 'Some reference updated the second time',
+    ];
+    $this->drupalPostAjaxForm(NULL, $edit, $this->getButtonName('//input[@type="submit" and @value="Update node" and @data-drupal-selector="edit-multi-form-inline-entity-form-entities-0-form-actions-ief-edit-save"]'));
+
+    // Save the second node after editing the reference.
+    $edit = ['title[0][value]' => 'Second node updated'];
+    $this->drupalPostForm(NULL, $edit, t('Save'));
+
+    // Check if the referenced content could be edited.
+    $this->assertNoText('The content has either been modified by another user, or you have already submitted modifications. As a result, your changes cannot be saved.', 'The referenced content could be edited.');
+  }
+
+  /**
+   * Creates ief_reference_type nodes which shall serve as reference nodes.
+   *
+   * @param int $numNodes
+   *   The number of nodes to create
+   * @return array
+   *   Array of created node ids keyed by labels.
+   */
+  protected function createReferenceContent($numNodes = 3) {
+    $retval = [];
+    for ($i = 1; $i <= $numNodes; $i++) {
+      $this->drupalCreateNode([
+        'type' => 'ief_reference_type',
+        'title' => 'Some reference ' . $i,
+        'first_name' => 'First Name ' . $i,
+        'last_name' => 'Last Name ' . $i,
+      ]);
+      $node = $this->drupalGetNodeByTitle('Some reference ' . $i);
+      $this->assertTrue($node, 'Created ief_reference_type node "' . $node->label() . '"');
+      $retval[$node->label()] = $node->id();
+    }
+    return $retval;
+  }
+
+  /**
+   * Sets allow_existing IEF setting.
+   *
+   * @param bool $flag
+   *   "allow_existing" flag to be set.
+   */
+  protected function setAllowExisting($flag) {
+    /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $display */
+    $display = $this->entityFormDisplayStorage->load('node.ief_test_complex.default');
+    $component = $display->getComponent('multi');
+    $component['settings']['allow_existing'] = $flag;
+    $display->setComponent('multi', $component)->save();
+  }
+
+  /**
+   * Creates a node for every node bundle.
+   *
+   * @return array
+   *   Array of node titles keyed by ids.
+   */
+  protected function createNodeForEveryBundle() {
+    $retval = [];
+    $bundles = $this->container->get('entity.manager')->getBundleInfo('node');
+    foreach ($bundles as $id => $value) {
+      $this->drupalCreateNode(['type' => $id, 'title' => $value['label']]);
+      $node = $this->drupalGetNodeByTitle($value['label']);
+      $this->assertTrue($node, 'Created node "' . $node->label() . '"');
+      $retval[$node->id()] = $value['label'];
+    }
+    return $retval;
+  }
+
+  /**
+   * Set up the ief_test_nested1 node add form.
+   *
+   * Sets the nested fields' required settings.
+   * Gets the form.
+   * Opens the inline entity forms if they are not required.
+   *
+   * @param boolean $required
+   *   Whether the fields are required.
+   * @param array $permissions
+   *   (optional) Permissions to sign testing user in with. You may pass in an
+   *   empty array (default) to use the all the permissions necessary create and
+   *   edit nodes on the form.
+   */
+  protected function setupNestedComplexForm($required, $permissions = []) {
+    /** @var \Drupal\Core\Field\FieldConfigInterface $ief_test_nested1 */
+    $ief_test_nested1 = $this->fieldConfigStorage->load('node.ief_test_nested1.test_ref_nested1');
+    $ief_test_nested1->setRequired($required);
+    $ief_test_nested1->save();
+    /** @var \Drupal\Core\Field\FieldConfigInterface $ief_test_nested2 */
+    $ief_test_nested2 = $this->fieldConfigStorage->load('node.ief_test_nested2.test_ref_nested2');
+    $ief_test_nested2->setRequired($required);
+    $ief_test_nested2->save();
+
+    if (!$permissions) {
+      $permissions = [
+        'create ief_test_nested1 content',
+        'create ief_test_nested2 content',
+        'create ief_test_nested3 content',
+        'edit any ief_test_nested1 content',
+        'edit any ief_test_nested2 content',
+        'edit any ief_test_nested3 content',
+      ];
+    }
+    $this->user = $this->createUser($permissions);
+    $this->drupalLogin($this->user);
+
+    $this->drupalGet('node/add/ief_test_nested1');
+
+    if (!$required) {
+      // Open inline forms if not required.
+      if (in_array('create ief_test_nested2 content', $permissions)) {
+        $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @value="Add new node 2"]'));
+      }
+      if (in_array('create ief_test_nested3 content', $permissions)) {
+        $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @value="Add new node 3"]'));
+      }
+    }
+  }
+
+  /**
+   * Closes the existing node form on the "multi" field.
+   */
+  protected function cancelExistingMultiForm($edit) {
+    $this->drupalPostAjaxForm(NULL, $edit, $this->getButtonName('//input[@type="submit" and @data-drupal-selector="edit-multi-form-actions-ief-reference-cancel"]'));
+    $this->assertNoFieldByName('multi[form][entity_id]', NULL, 'Existing entity reference autocomplete field removed.');
+  }
+
+  /**
+   * Opens the existing node form on the "multi" field.
+   */
+  protected function openMultiExistingForm() {
+    $this->drupalPostAjaxForm(NULL, [], $this->getButtonName('//input[@type="submit" and @value="Add existing node" and @data-drupal-selector="edit-multi-actions-ief-add-existing"]'));
+    $this->assertResponse(200, 'Opening reference form was successful.');
+    $this->assertFieldByName('multi[form][entity_id]', NULL, 'Existing entity reference autocomplete field found.');
+  }
+
+  /**
+   * Checks that an invalid value for an existing node will be display the expected error.
+   *
+   * @param $existing_node_text
+   *  The text to enter into the existing node text field.
+   * @param $expected_error
+   *  The error message that is expected to be shown.
+   */
+  protected function checkExistingValidationExpectation($existing_node_text, $expected_error) {
+    $edit = [
+      'multi[form][entity_id]' => $existing_node_text,
+    ];
+    $this->openMultiExistingForm();
+
+    $this->drupalPostAjaxForm(NULL, $edit, $this->getButtonName('//input[@type="submit" and @data-drupal-selector="edit-multi-form-actions-ief-reference-save"]'));
+    $this->assertText($expected_error);
+    $this->cancelExistingMultiForm($edit);
+  }
+
+  /**
+   * Tests entity create access is correct on nested IEF forms.
+   */
+  public function testNestedEntityCreateAccess() {
+    $permissions = [
+      'create ief_test_nested1 content',
+      'create ief_test_nested2 content',
+    ];
+    $this->setupNestedComplexForm(TRUE, $permissions);
+    $this->assertFieldByName('title[0][value]');
+    $this->assertFieldByName('test_ref_nested1[form][inline_entity_form][title][0][value]');
+    $this->assertNoFieldByName('test_ref_nested1[form][inline_entity_form][test_ref_nested2][form][inline_entity_form][title][0][value]', NULL);
+
+    $this->setupNestedComplexForm(FALSE, $permissions);
+    $this->assertNoFieldByXPath('//input[@type="submit" and @value="Add new node 3"]');
+  }
+
+  /**
+   * Tests create access on IEF Complex content type.
+   */
+  public function testComplexEntityCreate() {
+    $user = $this->createUser([
+      'create ief_test_complex content',
+    ]);
+    $this->drupalLogin($user);
+
+    $this->drupalGet('node/add/ief_test_complex');
+    $this->assertNoFieldByName('all_bundles[actions][bundle]', NULL, 'Bundle select is not shown when only one bundle is available.');
+    $this->assertNoFieldByName('multi[form][inline_entity_form][title][0][value]', NULL);
+
+    $user = $this->createUser([
+      'create ief_test_complex content',
+      'create ief_reference_type content'
+    ]);
+    $this->drupalLogin($user);
+
+    $this->drupalGet('node/add/ief_test_complex');
+    $this->assertFieldByName('all_bundles[actions][bundle]', NULL, 'Bundle select is shown when more than one bundle is available.');
+    $this->assertOption('edit-all-bundles-actions-bundle', 'ief_reference_type');
+    $this->assertOption('edit-all-bundles-actions-bundle', 'ief_test_complex');
+    $this->assertFieldByName('multi[form][inline_entity_form][title][0][value]');
+  }
+
+  /**
+   * Checks if nested nodes for ief_test_nested1 content were created correctly.
+   *
+   * @param $nested1_title
+   *   Expected title of top level node of the type ief_test_nested1
+   * @param $nested2_title
+   *   Expected title of second level node
+   * @param $nested3_title
+   *   Expected title of third level node
+   */
+  protected function checkNestedNodes($nested1_title, $nested2_title, $nested3_title) {
+    $nested1_node = $this->drupalGetNodeByTitle($nested1_title);
+    $this->assertEqual($nested1_title, $nested1_node->label(), "First node's title looks correct.");
+    $this->assertEqual('ief_test_nested1', $nested1_node->bundle(), "First node's type looks correct.");
+    if ($this->assertNotNull($nested1_node->test_ref_nested1->entity, 'Second node was created.')) {
+      $this->assertEqual($nested1_node->test_ref_nested1->count(), 1, 'Only 1 node created at first level.');
+      $this->assertEqual($nested2_title, $nested1_node->test_ref_nested1->entity->label(), "Second node's title looks correct.");
+      $this->assertEqual('ief_test_nested2', $nested1_node->test_ref_nested1->entity->bundle(), "Second node's type looks correct.");
+      if ($this->assertNotNull($nested1_node->test_ref_nested1->entity->test_ref_nested2->entity, 'Third node was created')) {
+        $this->assertEqual($nested1_node->test_ref_nested1->entity->test_ref_nested2->count(), 1, 'Only 1 node created at second level.');
+        $this->assertEqual($nested3_title, $nested1_node->test_ref_nested1->entity->test_ref_nested2->entity->label(), "Third node's title looks correct.");
+        $this->assertEqual('ief_test_nested3', $nested1_node->test_ref_nested1->entity->test_ref_nested2->entity->bundle(), "Third node's type looks correct.");
+
+        $this->checkNestedEntityEditing($nested1_node, TRUE);
+      }
+    }
+  }
+
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Tests/ElementWebTest.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Tests/ElementWebTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\inline_entity_form\Tests;
+
+/**
+ * Tests the IEF element on a custom form.
+ *
+ * @group inline_entity_form
+ */
+class ElementWebTest extends InlineEntityFormTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = ['inline_entity_form_test'];
+
+  /**
+   * Prepares environment for
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->user = $this->createUser([
+      'create ief_simple_single content',
+      'edit any ief_test_custom content',
+      'view own unpublished content',
+      'administer nodes',
+    ]);
+
+    $this->drupalLogin($this->user);
+
+    $this->fieldStorageConfigStorage = $this->container
+      ->get('entity_type.manager')
+      ->getStorage('field_storage_config');
+  }
+
+  /**
+   * Tests IEF on a custom form.
+   */
+  public function testCustomFormIEF() {
+    $form_mode_possibilities = [
+      'default',
+      'inline',
+    ];
+    foreach ($form_mode_possibilities as $form_mode_possibility) {
+      $title = $this->randomMachineName();
+      $this->drupalGet("ief-test/$form_mode_possibility");
+      $this->assertText(t('Title'), 'Title field found on the form.');
+      $this->assertText(t('Positive int'), 'Positive int field found on form.');
+      $this->checkFormDisplayFields("node.ief_test_custom.$form_mode_possibility", 'inline_entity_form');
+
+      $edit = [];
+      $this->drupalPostForm('ief-test', $edit, t('Save'));
+      $this->assertText('Title field is required.');
+      // Currently this assert will fail
+      //$this->assertNoText('This value should not be null.');
+      $this->assertNoNodeByTitle($title);
+
+      $edit['inline_entity_form[title][0][value]'] = $title;
+      $edit['inline_entity_form[positive_int][0][value]'] = -1;
+      $this->drupalPostForm('ief-test', $edit, t('Save'));
+      $this->assertText('Positive int must be higher than or equal to 1');
+      $this->assertNoNodeByTitle($title);
+
+      $edit['inline_entity_form[positive_int][0][value]'] = 11;
+      $this->drupalPostForm('ief-test', $edit, t('Save'));
+      $message = t('Created @entity_type @label.', ['@entity_type' => t('Content'), '@label' => $edit['inline_entity_form[title][0][value]']]);
+      $this->assertText($message, 'Status message found on the page.');
+      $this->assertNodeByTitle($title, 'ief_test_custom');
+
+      if ($node = $this->getNodeByTitle($title)) {
+        $this->drupalGet("ief-edit-test/{$node->id()}/$form_mode_possibility");
+        $this->assertFieldByName('inline_entity_form[title][0][value]', $title, 'Node title appears in form.');
+        $this->checkFormDisplayFields("node.ief_test_custom.$form_mode_possibility", 'inline_entity_form');
+        //$this->assertText($title, 'Node title appears in form.');
+        $this->assertFieldByName('inline_entity_form[positive_int][0][value]', 11, 'Positive int field appears in form.');
+        $updated_title = $title . ' - updated';
+        $edit['inline_entity_form[title][0][value]'] = $updated_title;
+        $this->drupalPostForm(NULL, $edit, t('Update'));
+        $this->assertNodeByTitle($updated_title, 'ief_test_custom');
+      }
+    }
+  }
+
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Tests/InlineEntityFormTestBase.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Tests/InlineEntityFormTestBase.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Drupal\inline_entity_form\Tests;
+
+use Drupal\simpletest\WebTestBase;
+
+/**
+ * Base Class for Inline Entity Form Tests.
+ */
+abstract class InlineEntityFormTestBase extends WebTestBase {
+
+  /**
+   * User with permissions to create content.
+   *
+   * @var \Drupal\user\Entity\User
+   */
+  protected $user;
+
+  /**
+   * Node storage.
+   *
+   * @var \Drupal\Core\Entity\ContentEntityStorageInterface;
+   */
+  protected $nodeStorage;
+
+  /**
+   * Field config storage.
+   *
+   * @var \Drupal\Core\Config\Entity\ConfigEntityStorage
+   */
+  protected $fieldStorageConfigStorage;
+
+  /**
+   * Field config storage.
+   *
+   * @var \Drupal\Core\Config\Entity\ConfigEntityStorageInterface
+   */
+  protected $fieldConfigStorage;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->nodeStorage = $this->container->get('entity_type.manager')->getStorage('node');
+    $this->fieldStorageConfigStorage = $this->container->get('entity_type.manager')->getStorage('field_storage_config');
+    $this->fieldConfigStorage = $this->container->get('entity_type.manager')->getStorage('field_config');
+  }
+
+
+  /**
+   * Gets IEF button name.
+   *
+   * @param array $xpath
+   *   Xpath of the button.
+   *
+   * @return string
+   *   The name of the button.
+   */
+  protected function getButtonName($xpath) {
+    $retval = '';
+    /** @var \SimpleXMLElement[] $elements */
+    if ($elements = $this->xpath($xpath)) {
+      foreach ($elements[0]->attributes() as $name => $value) {
+        if ($name == 'name') {
+          $retval = $value;
+          break;
+        }
+      }
+    }
+    return $retval;
+  }
+
+  /**
+   * Passes if no node is found for the title.
+   *
+   * @param $title
+   *   Node title to check.
+   * @param $message
+   *   Message to display.
+   */
+  protected function assertNoNodeByTitle($title, $message = '') {
+    if (!$message) {
+      $message = "No node with title: $title";
+    }
+    $node = $this->getNodeByTitle($title);
+
+    $this->assertTrue(empty($node), $message);
+  }
+
+  /**
+   * Passes if node is found for the title.
+   *
+   * @param $title
+   *   Node title to check.
+   * @param $message
+   *   Message to display.
+   */
+  protected function assertNodeByTitle($title, $bundle = NULL, $message = '') {
+    if (!$message) {
+      $message = "Node with title found: $title";
+    }
+    $node = $this->getNodeByTitle($title);
+    if ($this->assertTrue(!empty($node), $message)) {
+      if ($bundle) {
+        $this->assertEqual($node->bundle(), $bundle, "Node is correct bundle: $bundle");
+      }
+    }
+  }
+
+  /**
+   * Checks for check correct fields on form displays based on exported config
+   * in inline_entity_form_test module.
+   *
+   * @param $form_display
+   *  The form display to check.
+   */
+  protected function checkFormDisplayFields($form_display, $prefix) {
+    $form_display_fields = [
+      'node.ief_test_custom.default' => [
+        'expected' => [
+          '[title][0][value]',
+          '[uid][0][target_id]',
+          '[created][0][value][date]',
+          '[created][0][value][time]',
+          '[promote][value]',
+          '[sticky][value]',
+          '[positive_int][0][value]',
+        ],
+        'unexpected' => [],
+      ],
+      'node.ief_test_custom.inline' => [
+        'expected' => [
+          '[title][0][value]',
+          '[positive_int][0][value]',
+        ],
+        'unexpected' => [
+          '[uid][0][target_id]',
+          '[created][0][value][date]',
+          '[created][0][value][time]',
+          '[promote][value]',
+          '[sticky][value]',
+        ],
+      ],
+    ];
+    if ($fields = $form_display_fields[$form_display]) {
+      $this->assert('debug', 'Checking form dispaly: '. $form_display);
+      foreach ($fields['expected'] as $expected_field) {
+        $this->assertFieldByName($prefix . $expected_field);
+      }
+      foreach ($fields['unexpected'] as $unexpected_field) {
+        $this->assertNoFieldByName($prefix . $unexpected_field, NULL);
+      }
+    }
+    else {
+      // Test calling unexported form display if we are here.
+      throw new \Exception('Form display not found: ' . $form_display);
+    }
+  }
+
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Tests/SimpleWidgetWebTest.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/src/Tests/SimpleWidgetWebTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Drupal\inline_entity_form\Tests;
+
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Tests the IEF simple widget.
+ *
+ * @group inline_entity_form
+ */
+class SimpleWidgetWebTest extends InlineEntityFormTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = ['inline_entity_form_test'];
+
+  /**
+   * Prepares environment for
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->user = $this->createUser([
+      'create ief_simple_single content',
+      'create ief_test_custom content',
+      'edit any ief_simple_single content',
+      'edit own ief_test_custom content',
+      'view own unpublished content',
+    ]);
+  }
+
+  /**
+   * Tests simple IEF widget with different cardinality options.
+   *
+   * @throws \Exception
+   */
+  protected function testSimpleCardinalityOptions() {
+    $this->drupalLogin($this->user);
+    $cardinality_options = [
+      1 => 1,
+      2 => 2,
+      FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED => 3,
+    ];
+    /** @var \Drupal\field\FieldStorageConfigInterface $field_storage */
+    $field_storage = $this->fieldStorageConfigStorage->load('node.single');
+    foreach ($cardinality_options as $cardinality => $limit) {
+      $field_storage->setCardinality($cardinality);
+      $field_storage->save();
+
+      $this->drupalGet('node/add/ief_simple_single');
+
+      $this->assertText('Single node', 'Inline entity field widget title found.');
+      $this->assertText('Reference a single node.', 'Inline entity field description found.');
+
+      $add_more_xpath = '//input[@data-drupal-selector="edit-single-add-more"]';
+      if ($cardinality == FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED) {
+        $this->assertFieldByXPath($add_more_xpath, NULL, 'Add more button exists');
+      }
+      else {
+        $this->assertNoFieldByXPath($add_more_xpath, NULL, 'Add more button does NOT exist');
+      }
+
+      $host_title = 'Host node cardinality: ' . $cardinality;
+      $edit = ['title[0][value]' => $host_title];
+      for ($item_number = 0; $item_number < $limit; $item_number++) {
+        $edit["single[$item_number][inline_entity_form][title][0][value]"] = 'Child node nr.' . $item_number;
+        if ($cardinality == FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED) {
+          $next_item_number = $item_number + 1;
+          $this->assertNoFieldByName("single[$next_item_number][inline_entity_form][title][0][value]", NULL, "Item $next_item_number does not appear before 'Add More' clicked");
+          if ($item_number < $limit - 1) {
+            $this->drupalPostAjaxForm(NULL, $edit, 'single_add_more');
+            $this->assertFieldByName("single[$next_item_number][inline_entity_form][title][0][value]", NULL, "Item $next_item_number does  appear after 'Add More' clicked");
+            // Make sure only 1 item is added.
+            $unexpected_item_number = $next_item_number + 1;
+            $this->assertNoFieldByName("single[$unexpected_item_number][inline_entity_form][title][0][value]", NULL, "Extra Item $unexpected_item_number is not added after 'Add More' clicked");
+          }
+        }
+      }
+      $this->drupalPostForm(NULL, $edit, t('Save'));
+
+      for ($item_number = 0; $item_number < $limit; $item_number++) {
+        $this->assertText('Child node nr.' . $item_number, 'Label of referenced entity found.');
+      }
+
+      $host_node = $this->getNodeByTitle($host_title);
+      $this->checkEditAccess($host_node, $limit, $cardinality);
+    }
+  }
+
+  /**
+   * Test Validation on Simple Widget.
+   *
+   * @throws \Exception
+   */
+  protected function testSimpleValidation() {
+    $this->drupalLogin($this->user);
+    $host_node_title = 'Host Validation Node';
+    $this->drupalGet('node/add/ief_simple_single');
+
+    $this->assertText('Single node', 'Inline entity field widget title found.');
+    $this->assertText('Reference a single node.', 'Inline entity field description found.');
+    $this->assertText('Positive int', 'Positive int field found.');
+
+    $edit = ['title[0][value]' => $host_node_title];
+    $this->drupalPostForm(NULL, $edit, t('Save'));
+
+    $this->assertText('Title field is required.', 'Title validation fires on Inline Entity Form widget.');
+    $this->assertUrl('node/add/ief_simple_single', [], 'On add page after validation error.');
+
+    $child_title = 'Child node ' . $this->randomString();
+    $edit['single[0][inline_entity_form][title][0][value]'] = $child_title;
+    $edit['single[0][inline_entity_form][positive_int][0][value]'] = -1;
+    $this->drupalPostForm(NULL, $edit, t('Save'));
+    $this->assertNoText('Title field is required.', 'Title validation passes on Inline Entity Form widget.');
+    $this->assertText('Positive int must be higher than or equal to 1', 'Field validation fires on Inline Entity Form widget.');
+    $this->assertUrl('node/add/ief_simple_single', [], 'On add page after validation error.');
+
+    $edit['single[0][inline_entity_form][positive_int][0][value]'] = 1;
+    $this->drupalPostForm(NULL, $edit, t('Save'));
+    $this->assertNoText('Title field is required.', 'Title validation passes on Inline Entity Form widget.');
+    $this->assertNoText('Positive int must be higher than or equal to 1', 'Field validation fires on Inline Entity Form widget.');
+
+    // Check that nodes were created correctly.
+    $host_node = $this->getNodeByTitle($host_node_title);
+    if ($this->assertNotNull($host_node, 'Host node created.')) {
+      $this->assertUrl('node/' . $host_node->id(), [], 'On node view page after node add.');
+      $child_node = $this->getNodeByTitle($child_title);
+      if ($this->assertNotNull($child_node)) {
+        $this->assertEqual($host_node->single[0]->target_id, $child_node->id(), 'Child node is referenced');
+        $this->assertEqual($child_node->positive_int[0]->value,1, 'Child node int field correct.');
+        $this->assertEqual($child_node->bundle(),'ief_test_custom', 'Child node is correct bundle.');
+      }
+    }
+  }
+
+  /**
+   * Tests if the entity create access works in simple widget.
+   */
+  public function testSimpleCreateAccess() {
+    // Create a user who does not have access to create ief_test_custom nodes.
+    $this->user = $this->createUser([
+      'create ief_simple_single content',
+    ]);
+    $this->drupalLogin($this->user);
+    $this->drupalGet('node/add/ief_simple_single');
+    $this->assertNoFieldByName('single[0][inline_entity_form][title][0][value]', NULL);
+  }
+
+  /**
+   * Tests that user only has access to the their own nodes.
+   *
+   * @param \Drupal\node\Entity\Node $host_node
+   *   The node of the type of ief_simple_single
+   * @param int $child_count
+   *   The number of entity reference values in the "single" field.
+   */
+  protected function checkEditAccess(NodeInterface $host_node, $child_count, $cardinality) {
+    $other_user = $this->createUser([
+      'edit own ief_test_custom content',
+      'edit any ief_simple_single content',
+    ]);
+    /** @var  \Drupal\node\Entity\Node $first_child_node */
+    $first_child_node = $host_node->single[0]->entity;
+    $first_child_node->setOwner($other_user);
+    $first_child_node->save();
+    $this->drupalGet("node/{$host_node->id()}/edit");
+    $this->assertText($first_child_node->label());
+    $this->assertNoFieldByName('single[0][inline_entity_form][title][0][value]', NULL, 'Form of child node with no edit access is not found.');
+    // Check that the forms for other child nodes(if any) appear on the form.
+    $delta = 1;
+    while ($delta < $child_count) {
+      /** @var \Drupal\node\Entity\Node $child_node */
+      $child_node = $host_node->single[$delta]->entity;
+      $this->assertFieldByName("single[$delta][inline_entity_form][title][0][value]", $child_node->label(), 'Form of child node with edit access is found.');
+      $delta++;
+    }
+    // Check that there is NOT an extra "add" form when editing.
+    $unexpected_item_number = $child_count;
+    $this->assertNoFieldByName("single[$unexpected_item_number][inline_entity_form][title][0][value]", NULL, 'No empty "add" entity form is found on edit.');
+    if ($cardinality == FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED) {
+      $next_item_number = $child_count;
+      $this->drupalPostAjaxForm(NULL, [], 'single_add_more');
+      $this->assertFieldByName("single[$next_item_number][inline_entity_form][title][0][value]", NULL, "Item $next_item_number does appear after 'Add More' clicked");
+      // Make sure only 1 item is added.
+      $unexpected_item_number = $next_item_number + 1;
+      $this->assertNoFieldByName("single[$unexpected_item_number][inline_entity_form][title][0][value]", NULL, "Extra Item $unexpected_item_number is not added after 'Add More' clicked");
+    }
+
+    // Now that we have confirmed the correct fields appear, lets update the
+    // values and save them. We do not have access to form for delta 0 because
+    // it is owned by another user.
+    $delta = 1;
+    $new_titles = [];
+    $edit = [];
+    // Loop through an update all child node titles.
+    while ($delta < $child_count) {
+      /** @var \Drupal\node\Entity\Node $child_node */
+      $child_node = $host_node->single[$delta]->entity;
+      $new_titles[$delta] = $child_node->label() . ' - updated';
+      $edit["single[$delta][inline_entity_form][title][0][value]"] = $new_titles[$delta];
+      $delta++;
+    }
+    // If CARDINALITY_UNLIMITED then we should have 1 extra form open.
+    if ($cardinality == FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED) {
+      $new_titles[$delta] = 'Title for new child';
+      $edit["single[$delta][inline_entity_form][title][0][value]"] = $new_titles[$delta];
+    }
+    $this->drupalPostForm(NULL, $edit, t('Save'));
+    $this->assertText("IEF single simple {$host_node->label()} has been updated.");
+
+    // Reset cache for nodes.
+    $node_ids = [$host_node->id()];
+    foreach ($host_node->single as $item) {
+      $node_ids[] = $item->entity->id();
+    }
+    $this->nodeStorage->resetCache($node_ids);
+    $host_node = $this->nodeStorage->load($host_node->id());
+    // Check that titles were updated.
+    foreach ($new_titles as $delta => $new_title) {
+      $child_node = $host_node->single[$delta]->entity;
+      $this->assertEqual($child_node->label(), $new_title, "Child $delta node title updated");
+    }
+  }
+
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/src/WidgetSubmit.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/src/WidgetSubmit.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\inline_entity_form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\inline_entity_form\Element\InlineEntityForm;
+
+/**
+ * Performs widget submission.
+ *
+ * Widgets don't save changed entities, nor do they delete removed entities.
+ * Instead, they flag them so that changes are only applied when the main form
+ * is submitted.
+ */
+class WidgetSubmit {
+
+  /**
+   * Attaches the widget submit functionality to the given form.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public static function attach(&$form, FormStateInterface $form_state) {
+    // $form['#ief_element_submit'] runs after the #ief_element_submit
+    // callbacks of all subelements, which means that doSubmit() has
+    // access to the final IEF $form_state.
+    $form['#ief_element_submit'][] = [get_called_class(), 'doSubmit'];
+  }
+
+  /**
+   * Submits the widget elements, saving and deleted entities where needed.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public static function doSubmit(array $form, FormStateInterface $form_state) {
+    foreach ($form_state->get('inline_entity_form') as &$widget_state) {
+      $widget_state += ['entities' => [], 'delete' => []];
+
+      foreach ($widget_state['entities'] as $delta => $entity_item) {
+        if (!empty($entity_item['entity']) && !empty($entity_item['needs_save'])) {
+          /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+          $entity = $entity_item['entity'];
+          $handler = InlineEntityForm::getInlineFormHandler($entity->getEntityTypeId());
+          $handler->save($entity);
+          $widget_state['entities'][$delta]['needs_save'] = FALSE;
+        }
+      }
+
+      /** @var \Drupal\Core\Entity\ContentEntityInterface $entities */
+      foreach ($widget_state['delete'] as $entity) {
+        $entity->delete();
+      }
+      unset($widget_state['delete']);
+    }
+  }
+
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_complex_simple.default.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_complex_simple.default.yml
@@ -1,0 +1,63 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.ief_complex_simple.ief_complex_outer
+    - node.type.ief_complex_simple
+  module:
+    - inline_entity_form
+id: node.ief_complex_simple.default
+targetEntityType: node
+bundle: ief_complex_simple
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  ief_complex_outer:
+    weight: 26
+    settings:
+      match_operator: CONTAINS
+      form_mode: default
+      override_labels: false
+      label_singular: ''
+      label_plural: ''
+      allow_new: true
+      allow_existing: false
+    third_party_settings: {  }
+    type: inline_entity_form_complex
+  langcode:
+    type: language_select
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_reference_type.default.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_reference_type.default.yml
@@ -1,0 +1,57 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.ief_reference_type
+id: node.ief_reference_type.default
+targetEntityType: node
+bundle: ief_reference_type
+mode: default
+content:
+  title:
+    type: string_textfield
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  first_name:
+    type: string_textfield
+    weight: 5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  last_name:
+    type: string_textfield
+    weight: 6
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_simple_single.default.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_simple_single.default.yml
@@ -1,0 +1,53 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.ief_simple_single
+id: node.ief_simple_single.default
+targetEntityType: node
+bundle: ief_simple_single
+mode: default
+content:
+  title:
+    type: string_textfield
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  single:
+    weight: 30
+    settings:
+      match_operator: CONTAINS
+      allow_existing: false
+      override_labels: false
+      label_singular: ''
+      label_plural: ''
+    third_party_settings: {  }
+    type: inline_entity_form_simple
+hidden: {  }

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_complex.default.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_complex.default.yml
@@ -1,0 +1,70 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.ief_test_complex
+id: node.ief_test_complex.default
+targetEntityType: node
+bundle: ief_test_complex
+mode: default
+content:
+  title:
+    type: string_textfield
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  multi:
+    weight: 30
+    settings:
+      match_operator: CONTAINS
+      allow_existing: false
+      override_labels: false
+      label_singular: ''
+      label_plural: ''
+    third_party_settings: {  }
+    type: inline_entity_form_complex
+  image:
+    type: image_image
+    weight: 4
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  all_bundles:
+    weight: 30
+    settings:
+      match_operator: CONTAINS
+      allow_existing: true
+      override_labels: false
+      label_singular: ''
+      label_plural: ''
+    third_party_settings: {  }
+    type: inline_entity_form_complex
+hidden: {  }

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_custom.default.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_custom.default.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.ief_test_custom.positive_int
+    - node.type.ief_test_custom
+id: node.ief_test_custom.default
+targetEntityType: node
+bundle: ief_test_custom
+mode: default
+content:
+  title:
+    type: string_textfield
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  positive_int:
+    weight: 26
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: number
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_custom.inline.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_custom.inline.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.node.inline
+    - field.field.node.ief_test_custom.positive_int
+    - node.type.ief_test_custom
+_core:
+  default_config_hash: ulZ9aLpVyfyaKg--5wsjuuRcYj6fNv0bw2MB-BDCq_Q
+id: node.ief_test_custom.inline
+targetEntityType: node
+bundle: ief_test_custom
+mode: inline
+content:
+  positive_int:
+    weight: 1
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: number
+  title:
+    type: string_textfield
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  promote: true
+  sticky: true
+  uid: true

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_nested1.default.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_nested1.default.yml
@@ -1,0 +1,53 @@
+langcode: und
+status: true
+dependencies:
+  config:
+    - node.type.ief_test_nested1
+id: node.ief_test_nested1.default
+targetEntityType: node
+bundle: ief_test_nested1
+mode: default
+content:
+  title:
+    type: string_textfield
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  test_ref_nested1:
+    weight: 30
+    settings:
+      match_operator: CONTAINS
+      allow_existing: false
+      override_labels: true
+      label_singular: 'node 2'
+      label_plural: 'nodes 2'
+    third_party_settings: {  }
+    type: inline_entity_form_complex
+hidden: {  }

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_nested2.default.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_nested2.default.yml
@@ -1,0 +1,53 @@
+langcode: und
+status: true
+dependencies:
+  config:
+    - node.type.ief_test_nested2
+id: node.ief_test_nested2.default
+targetEntityType: node
+bundle: ief_test_nested2
+mode: default
+content:
+  title:
+    type: string_textfield
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  test_ref_nested2:
+    weight: 30
+    settings:
+      match_operator: CONTAINS
+      allow_existing: false
+      override_labels: true
+      label_singular: 'node 3'
+      label_plural: 'nodes 3'
+    third_party_settings: {  }
+    type: inline_entity_form_complex
+hidden: {  }

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_nested3.default.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_nested3.default.yml
@@ -1,0 +1,43 @@
+langcode: und
+status: true
+dependencies:
+  config:
+    - node.type.ief_test_nested3
+id: node.ief_test_nested3.default
+targetEntityType: node
+bundle: ief_test_nested3
+mode: default
+content:
+  title:
+    type: string_textfield
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_mode.node.inline.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_form_mode.node.inline.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.inline
+label: Inline
+targetEntityType: node
+cache: true

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_view_display.node.ief_complex_simple.default.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_view_display.node.ief_complex_simple.default.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.ief_complex_simple.ief_complex_outer
+    - node.type.ief_complex_simple
+  module:
+    - user
+id: node.ief_complex_simple.default
+targetEntityType: node
+bundle: ief_complex_simple
+mode: default
+content:
+  ief_complex_outer:
+    weight: 101
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  links:
+    weight: 100
+hidden:
+  langcode: true

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_view_display.node.ief_complex_simple.teaser.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_view_display.node.ief_complex_simple.teaser.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.ief_complex_simple
+  module:
+    - user
+id: node.ief_complex_simple.teaser
+targetEntityType: node
+bundle: ief_complex_simple
+mode: teaser
+content:
+  links:
+    weight: 100
+hidden:
+  langcode: true

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_view_display.node.ief_simple_single.default.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/core.entity_view_display.node.ief_simple_single.default.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.ief_simple_single.single
+    - node.type.ief_simple_single
+  module:
+    - user
+id: node.ief_simple_single.default
+targetEntityType: node
+bundle: ief_simple_single
+mode: default
+content:
+  single:
+    type: entity_reference_label
+    weight: 0
+    label: above
+    settings:
+      link: false
+    third_party_settings: {  }
+hidden:
+  links: true

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_complex_simple.ief_complex_outer.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_complex_simple.ief_complex_outer.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.ief_complex_outer
+    - node.type.ief_complex_simple
+    - node.type.ief_simple_single
+id: node.ief_complex_simple.ief_complex_outer
+field_name: ief_complex_outer
+entity_type: node
+bundle: ief_complex_simple
+label: 'Complex Outer'
+description: 'Reference nodes with complex widget outer.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      ief_simple_single: ief_simple_single
+    sort:
+      field: _none
+field_type: entity_reference

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_reference_type.first_name.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_reference_type.first_name.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+id: node.ief_reference_type.first_name
+field_name: first_name
+entity_type: node
+bundle: ief_reference_type
+label: 'First name'
+description: ''
+required: true
+default_value: {  }
+default_value_callback: ''
+settings: { }
+field_type: text
+dependencies:
+  config:
+    - field.storage.node.first_name
+    - node.type.ief_reference_type

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_reference_type.last_name.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_reference_type.last_name.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+id: node.ief_reference_type.last_name
+field_name: last_name
+entity_type: node
+bundle: ief_reference_type
+label: 'Last name'
+description: ''
+required: true
+default_value: {  }
+default_value_callback: ''
+settings: { }
+field_type: text
+dependencies:
+  config:
+    - field.storage.node.last_name
+    - node.type.ief_reference_type

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_simple_single.single.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_simple_single.single.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.single
+    - node.type.ief_simple_single
+    - node.type.ief_test_custom
+  module:
+    - inline_entity_form_test
+  enforced:
+    module:
+      - inline_entity_form_test
+id: node.ief_simple_single.single
+field_name: single
+entity_type: node
+bundle: ief_simple_single
+label: Single node
+description: 'Reference a single node.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings:
+    target_bundles:
+      ief_test_custom: ief_test_custom
+    sort:
+      field: _none
+third_party_settings: {  }
+field_type: entity_reference

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_complex.all_bundles.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_complex.all_bundles.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.all_bundles
+    - node.type.ief_test_complex
+  module:
+    - inline_entity_form_test
+  enforced:
+    module:
+      - inline_entity_form_test
+id: node.ief_test_complex.all_bundles
+field_name: all_bundles
+entity_type: node
+bundle: ief_test_complex
+label: All bundles
+description: 'Reference nodes from all available bundles.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default:node
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: _none
+third_party_settings: {  }
+field_type: entity_reference

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_complex.image.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_complex.image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.image
+    - node.type.ief_test_complex
+  module:
+    - image
+id: node.ief_test_complex.image
+field_name: image
+entity_type: node
+bundle: ief_test_complex
+label: Image
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  title_field: false
+  alt_field_required: true
+  title_field_required: false
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_complex.multi.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_complex.multi.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.multi
+    - node.type.ief_reference_type
+    - node.type.ief_test_custom
+  module:
+    - inline_entity_form_test
+  enforced:
+    module:
+      - inline_entity_form_test
+id: node.ief_test_complex.multi
+field_name: multi
+entity_type: node
+bundle: ief_test_complex
+label: Multiple nodes
+description: 'Reference multiple nodes.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      ief_reference_type: ief_reference_type
+    sort:
+      field: _none
+third_party_settings: {  }
+field_type: entity_reference

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_custom.positive_int.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_custom.positive_int.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.positive_int
+    - node.type.ief_test_custom
+id: node.ief_test_custom.positive_int
+field_name: positive_int
+entity_type: node
+bundle: ief_test_custom
+label: 'Positive int'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 1
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_nested1.test_ref_nested1.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_nested1.test_ref_nested1.yml
@@ -1,0 +1,31 @@
+langcode: und
+status: true
+dependencies:
+  config:
+    - field.storage.node.test_ref_nested1
+    - node.type.ief_test_nested1
+  module:
+    - inline_entity_form_test
+    - entity_reference
+  enforced:
+    module:
+      - inline_entity_form_test
+id: node.ief_test_nested1.test_ref_nested1
+field_name: test_ref_nested1
+entity_type: node
+bundle: ief_test_nested1
+label: Multiple nodes
+description: 'Reference multiple nodes.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default:node
+  handler_settings:
+    target_bundles:
+      ief_reference_type: ief_test_nested2
+    sort:
+      field: _none
+third_party_settings: {  }
+field_type: entity_reference

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_nested2.test_ref_nested2.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_nested2.test_ref_nested2.yml
@@ -1,0 +1,31 @@
+langcode: und
+status: true
+dependencies:
+  config:
+    - field.storage.node.test_ref_nested2
+    - node.type.ief_test_nested2
+  module:
+    - inline_entity_form_test
+    - entity_reference
+  enforced:
+    module:
+      - inline_entity_form_test
+id: node.ief_test_nested2.test_ref_nested2
+field_name: test_ref_nested2
+entity_type: node
+bundle: ief_test_nested2
+label: Multiple nodes
+description: 'Reference multiple nodes.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default:node
+  handler_settings:
+    target_bundles:
+      ief_reference_type: ief_test_nested3
+    sort:
+      field: _none
+third_party_settings: {  }
+field_type: entity_reference

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.all_bundles.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.all_bundles.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - inline_entity_form_test
+    - node
+  enforced:
+    module:
+      - inline_entity_form_test
+id: node.all_bundles
+field_name: all_bundles
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.first_name.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.first_name.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - inline_entity_form_test
+    - text
+    - node
+  enforced:
+    module:
+      - inline_entity_form_test
+id: node.first_name
+field_name: first_name
+entity_type: node
+type: text
+settings:
+  max_length: 255
+module: text
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.ief_complex_outer.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.ief_complex_outer.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.ief_complex_outer
+field_name: ief_complex_outer
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.image.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.image.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - node
+id: node.image
+field_name: image
+entity_type: node
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes:
+  target_id:
+    - target_id
+persist_with_no_fields: false
+custom_storage: false

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.last_name.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.last_name.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - inline_entity_form_test
+    - text
+    - node
+  enforced:
+    module:
+      - inline_entity_form_test
+id: node.last_name
+field_name: last_name
+entity_type: node
+type: text
+settings:
+  max_length: 255
+module: text
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.multi.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.multi.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - inline_entity_form_test
+    - node
+  enforced:
+    module:
+      - inline_entity_form_test
+id: node.multi
+field_name: multi
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.positive_int.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.positive_int.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.positive_int
+field_name: positive_int
+entity_type: node
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.single.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.single.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - inline_entity_form_test
+    - node
+  enforced:
+    module:
+      - inline_entity_form_test
+id: node.single
+field_name: single
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.test_ref_nested1.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.test_ref_nested1.yml
@@ -1,0 +1,22 @@
+langcode: und
+status: true
+dependencies:
+  module:
+    - inline_entity_form_test
+    - entity_reference
+    - node
+  enforced:
+    module:
+      - inline_entity_form_test
+id: node.test_ref_nested1
+field_name: test_ref_nested1
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: entity_reference
+locked: false
+cardinality: -1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.test_ref_nested2.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/field.storage.node.test_ref_nested2.yml
@@ -1,0 +1,22 @@
+langcode: und
+status: true
+dependencies:
+  module:
+    - inline_entity_form_test
+    - entity_reference
+    - node
+  enforced:
+    module:
+      - inline_entity_form_test
+id: node.test_ref_nested2
+field_name: test_ref_nested2
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: entity_reference
+locked: false
+cardinality: -1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_complex_simple.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_complex_simple.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'IEF complex -simple'
+type: ief_complex_simple
+description: 'Content type for IEF testing Complex widget containing simple widget'
+help: ''
+new_revision: false
+preview_mode: 0
+display_submitted: true

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_reference_type.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_reference_type.yml
@@ -1,0 +1,9 @@
+type: ief_reference_type
+name: IEF reference type
+description: 'Entity reference content type.'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: false
+status: true
+langcode: en

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_simple_single.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_simple_single.yml
@@ -1,0 +1,9 @@
+type: ief_simple_single
+name: IEF single simple
+description: 'Content type for testing simple IEF widget on a single-value field.'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: false
+status: true
+langcode: en

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_test_complex.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_test_complex.yml
@@ -1,0 +1,9 @@
+type: ief_test_complex
+name: IEF test complex
+description: 'Content type for IEF complex widget testing.'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: false
+status: true
+langcode: en

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_test_custom.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_test_custom.yml
@@ -1,0 +1,9 @@
+type: ief_test_custom
+name: IEF test custom
+description: 'Content type for IEF custom form testing.'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: false
+status: true
+langcode: en

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_test_nested1.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_test_nested1.yml
@@ -1,0 +1,9 @@
+type: ief_test_nested1
+name: IEF test nested 1
+description: 'Content type for IEF custom form testing.'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: false
+status: true
+langcode: und

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_test_nested2.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_test_nested2.yml
@@ -1,0 +1,9 @@
+type: ief_test_nested2
+name: IEF test nested 2
+description: 'Content type for IEF custom form testing.'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: false
+status: true
+langcode: und

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_test_nested3.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/config/install/node.type.ief_test_nested3.yml
@@ -1,0 +1,9 @@
+type: ief_test_nested3
+name: IEF test nested 3
+description: 'Content type for IEF custom form testing.'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: false
+status: true
+langcode: und

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/inline_entity_form_test.info.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/inline_entity_form_test.info.yml
@@ -1,0 +1,17 @@
+name: 'IEF test'
+type: module
+description: 'Support module for the Inline entity form module tests.'
+# core: 8.x
+package: Testing
+# version: VERSION
+dependencies:
+  - inline_entity_form
+  - node
+  - file
+  - image
+
+# Information added by Drupal.org packaging script on 2016-04-20
+version: '8.x-1.0-alpha6'
+core: '8.x'
+project: 'inline_entity_form'
+datestamp: 1461165841

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/inline_entity_form_test.routing.yml
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/inline_entity_form_test.routing.yml
@@ -1,0 +1,16 @@
+inline_entity_form_test.form:
+  path: '/ief-test/{form_mode}'
+  defaults:
+    _form: '\Drupal\inline_entity_form_test\IefTest'
+    _title: 'IEF test'
+    form_mode: 'default'
+  requirements:
+    _access: 'TRUE'
+inline_entity_form_test.edit_form:
+  path: '/ief-edit-test/{node}/{form_mode}'
+  defaults:
+    _form: '\Drupal\inline_entity_form_test\IefEditTest'
+    _title: 'IEF test'
+    form_mode: 'default'
+  requirements:
+    _access: 'TRUE'

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/src/IefEditTest.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/src/IefEditTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\inline_entity_form_test;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\Entity\Node;
+
+/**
+ * Tests Inline entity form element.
+ */
+class IefEditTest extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormID() {
+    return 'ief_edit_test';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, Node $node = NULL, $form_mode = 'default') {
+    $form['inline_entity_form'] = [
+      '#type' => 'inline_entity_form',
+      '#entity_type' => 'node',
+      '#bundle' => 'ief_test_custom',
+      '#default_value' => $node,
+      '#form_mode' => $form_mode,
+    ];
+    $form['submit'] = [
+      '#type' => 'submit',
+      '#value' => t('Update'),
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $entity = $form['inline_entity_form']['#entity'];
+    drupal_set_message(t('Created @entity_type @label.', ['@entity_type' => $entity->getEntityType()->getLabel(), '@label' => $entity->label()]));
+  }
+
+}

--- a/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/src/IefTest.php
+++ b/profiles/anonintergroup/modules/contrib/inline_entity_form/tests/modules/inline_entity_form_test/src/IefTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\inline_entity_form_test;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Tests Inline entity form element.
+ */
+class IefTest extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormID() {
+    return 'ief_test';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, $form_mode = 'default') {
+    $form['inline_entity_form'] = [
+      '#type' => 'inline_entity_form',
+      '#entity_type' => 'node',
+      '#bundle' => 'ief_test_custom',
+      '#form_mode' => $form_mode,
+    ];
+    $form['submit'] = [
+      '#type' => 'submit',
+      '#value' => t('Save'),
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $entity = $form['inline_entity_form']['#entity'];
+    drupal_set_message(t('Created @entity_type @label.', ['@entity_type' => $entity->getEntityType()->getLabel(), '@label' => $entity->label()]));
+  }
+
+}

--- a/profiles/anonintergroup/modules/custom/anongroups/anongroups.info.yml
+++ b/profiles/anonintergroup/modules/custom/anongroups/anongroups.info.yml
@@ -8,3 +8,4 @@ dependencies:
   - anonlocations
   - telephone
   - link
+  - inline_entity_form

--- a/profiles/anonintergroup/modules/custom/anongroups/config/install/core.entity_form_display.anongroup.anongroup.default.yml
+++ b/profiles/anonintergroup/modules/custom/anongroups/config/install/core.entity_form_display.anongroup.anongroup.default.yml
@@ -10,11 +10,12 @@ dependencies:
     - field.field.anongroup.anongroup.field_website
   module:
     - anongroups
+    - inline_entity_form
     - link
     - telephone
     - text
 _core:
-  default_config_hash: V3gVjqJNrV9V0nuYOwTg6HhSpliOySUZOSFt-9UdS3g
+  default_config_hash: AchUPhHY-2ftbdYiPENxVikcPI7mj3ZZgNHiABsoqSg
 id: anongroup.anongroup.default
 targetEntityType: anongroup
 bundle: anongroup
@@ -30,11 +31,15 @@ content:
   field_default_location:
     weight: 4
     settings:
+      form_mode: default
+      label_singular: ''
+      label_plural: ''
+      allow_new: true
       match_operator: CONTAINS
-      size: 60
-      placeholder: ''
+      override_labels: false
+      allow_existing: false
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: inline_entity_form_complex
   field_default_phone:
     type: telephone_default
     weight: 3

--- a/profiles/anonintergroup/modules/custom/anonmeetings/anonmeetings.info.yml
+++ b/profiles/anonintergroup/modules/custom/anonmeetings/anonmeetings.info.yml
@@ -9,3 +9,4 @@ dependencies:
   - anonlocations
   - weeklytime
   - rest
+  - inline_entity_form

--- a/profiles/anonintergroup/modules/custom/anonmeetings/config/install/core.entity_form_display.anonmeeting.anonmeeting.default.yml
+++ b/profiles/anonintergroup/modules/custom/anonmeetings/config/install/core.entity_form_display.anonmeeting.anonmeeting.default.yml
@@ -3,44 +3,53 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.anonmeeting.anonmeeting.field_format
     - field.field.anonmeeting.anonmeeting.field_group
     - field.field.anonmeeting.anonmeeting.field_location
     - field.field.anonmeeting.anonmeeting.field_time
-    - field.field.anonmeeting.anonmeeting.field_format
   module:
     - anonmeetings
+    - inline_entity_form
     - weeklytime
 _core:
-  default_config_hash: Ggg4_SOM-4nuzLg8J810CxYRVqkFs5A6WpZJ4pV2kcw
+  default_config_hash: JofweKAL-jryiFSfgYPBY2UWmL8IElatRvu-AzA7Wvk
 id: anonmeeting.anonmeeting.default
 targetEntityType: anonmeeting
 bundle: anonmeeting
 mode: default
 content:
+  field_format:
+    type: options_select
+    weight: 6
+    settings: {  }
+    third_party_settings: {  }
   field_group:
-    type: entity_reference_autocomplete_tags
+    type: inline_entity_form_complex
     weight: 2
     settings:
       match_operator: CONTAINS
-      size: 60
-      placeholder: ''
+      form_mode: default
+      override_labels: false
+      label_singular: ''
+      label_plural: ''
+      allow_new: true
+      allow_existing: false
     third_party_settings: {  }
   field_location:
     weight: 3
     settings:
       match_operator: CONTAINS
-      size: 60
-      placeholder: ''
+      form_mode: default
+      override_labels: false
+      label_singular: ''
+      label_plural: ''
+      allow_new: true
+      allow_existing: false
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: inline_entity_form_complex
   field_time:
     type: weeklytime_widget
     weight: 4
-    settings: {  }
-    third_party_settings: {  }
-  field_format:
-    type: options_select
-    weight: 6
     settings: {  }
     third_party_settings: {  }
   name:


### PR DESCRIPTION
See #6

This makes the editing experience of meetings and groups a bit better by, for example, when editing a meeting it embeds extra buttons and a form for editing the location and group, instead of relying on entity reference.
