### PR TITLE
Issue-46: add special events

### DIFF
--- a/modules/custom/twelvestepintergrouporg/twelvestepintergrouporg.install
+++ b/modules/custom/twelvestepintergrouporg/twelvestepintergrouporg.install
@@ -88,10 +88,6 @@ function twelvestepintergrouporg_install() {
     'status' => TRUE,
     'region' => 'highlighted',
     'plugin' => 'views_block:events-block_1',
-    'settings' => [
-      'label' => 'Events',
-      'label_display' => FALSE,
-    ],
     'visibility' => [
       'request_path' => [
         'id' => 'request_path',

--- a/modules/custom/twelvestepintergrouporg/twelvestepintergrouporg.install
+++ b/modules/custom/twelvestepintergrouporg/twelvestepintergrouporg.install
@@ -9,6 +9,7 @@ use Drupal\Core\Extension\ThemeInstaller;
 use Drupal\Core\Extension\ModuleInstaller;
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\block\Entity\Block;
+use Drupal\node\Entity\Node;
 use Drupal\twelvesteptheme\TwelveStepThemeHelper;
 
 /**
@@ -22,7 +23,8 @@ function twelvestepintergrouporg_install() {
     ->save(TRUE);
 
   // Change the default theme.
-  \Drupal::service('twelvestepmodule.default')->changeTheme('twelvesteporgtheme');
+  $default_theme = 'twelvesteporgtheme';
+  \Drupal::service('twelvestepmodule.default')->changeTheme($default_theme);
 
   // Import content.
   \Drupal::service('module_installer')->install(['twelvestepmigrate']);
@@ -43,7 +45,7 @@ function twelvestepintergrouporg_install() {
   $block->save();
   Block::create([
     'id' => 'aboutthissite',
-    'theme' => 'twelvesteporgtheme',
+    'theme' => $default_theme,
     'weight' => -3,
     'status' => TRUE,
     'region' => 'highlighted',
@@ -51,6 +53,50 @@ function twelvestepintergrouporg_install() {
     'settings' => [
       'label' => 'About this site',
       'label_display' => FALSE,
+    ],
+  ])->save();
+
+  // Create an event for NAATW.
+  $node = Node::create([
+    'type' => 'event',
+    'title' => 'NAATW 2016',
+    'langcode' => 'en',
+    'uid' => '1',
+    'status' => 1,
+    'body' => [
+      'value' => 'Join us for the third annual <a href="http://naatw.org">National AA Technology Workshop</a> in Winston Salem, NC this November as we discuss how we use technology in service of our primary purpose.',
+      'format' => 'basic_html',
+    ],
+    'field_start_date' => '2016-11-18T15:00:00',
+    'field_end_date' => '2016-11-20T11:00:00',
+    'field_address' => [
+      'organization' => 'Marriott Hotel',
+      'country_code' => 'US',
+      'administrative_area' => 'US-NC',
+      'locality' => 'Winston-Salem',
+      'postal_code' => '27101',
+      'address_line1' => '425 North Cherry St',
+    ],
+  ]);
+  $node->save();
+
+  // Create a block for Events.
+  Block::create([
+    'id' => 'events',
+    'theme' => $default_theme,
+    'weight' => -2,
+    'status' => TRUE,
+    'region' => 'highlighted',
+    'plugin' => 'views_block:events-block_1',
+    'settings' => [
+      'label' => 'Events',
+      'label_display' => FALSE,
+    ],
+    'visibility' => [
+      'request_path' => [
+        'id' => 'request_path',
+        'pages' => '<front>',
+      ],
     ],
   ])->save();
 }

--- a/profiles/twelvestepintergroup/config/install/core.entity_form_display.node.event.default.yml
+++ b/profiles/twelvestepintergroup/config/install/core.entity_form_display.node.event.default.yml
@@ -1,0 +1,92 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.event.body
+    - field.field.node.event.field_address
+    - field.field.node.event.field_end_date
+    - field.field.node.event.field_group
+    - field.field.node.event.field_start_date
+    - node.type.event
+  module:
+    - address
+    - datetime
+    - path
+    - text
+_core:
+  default_config_hash: JYhsh2cE4KA9NYGg2DkJDkd3KB2jyTCH34KMaqWmelc
+id: node.event.default
+targetEntityType: node
+bundle: event
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 31
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  field_address:
+    weight: 34
+    settings:
+      default_country: null
+    third_party_settings: {  }
+    type: address_default
+  field_end_date:
+    weight: 33
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+  field_group:
+    weight: 35
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+  field_start_date:
+    weight: 32
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+  path:
+    type: path
+    weight: 30
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/profiles/twelvestepintergroup/config/install/core.entity_view_display.node.event.default.yml
+++ b/profiles/twelvestepintergroup/config/install/core.entity_view_display.node.event.default.yml
@@ -1,0 +1,62 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.event.body
+    - field.field.node.event.field_address
+    - field.field.node.event.field_end_date
+    - field.field.node.event.field_group
+    - field.field.node.event.field_start_date
+    - node.type.event
+  module:
+    - address
+    - datetime
+    - text
+    - user
+_core:
+  default_config_hash: BsRZyTUrxY133s6nbt0emb1MVCZ6uJTOEzE5pL63A4k
+id: node.event.default
+targetEntityType: node
+bundle: event
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+  field_address:
+    weight: 4
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: address_default
+  field_end_date:
+    weight: 2
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+  field_group:
+    weight: 5
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  field_start_date:
+    weight: 1
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+  links:
+    weight: 6
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/profiles/twelvestepintergroup/config/install/core.entity_view_display.node.event.teaser.yml
+++ b/profiles/twelvestepintergroup/config/install/core.entity_view_display.node.event.teaser.yml
@@ -1,0 +1,45 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.event.body
+    - field.field.node.event.field_address
+    - field.field.node.event.field_end_date
+    - field.field.node.event.field_group
+    - field.field.node.event.field_start_date
+    - node.type.event
+  module:
+    - datetime
+    - text
+    - user
+_core:
+  default_config_hash: 1jJ0ioTRo0ix5AokcFmIEy2VvbRu_IzE6PuWUFQyk6k
+id: node.event.teaser
+targetEntityType: node
+bundle: event
+mode: teaser
+content:
+  body:
+    label: hidden
+    type: text_summary_or_trimmed
+    weight: 1
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+  field_start_date:
+    type: datetime_default
+    weight: 0
+    label: hidden
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+  links:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_address: true
+  field_end_date: true
+  field_group: true

--- a/profiles/twelvestepintergroup/config/install/field.field.node.event.body.yml
+++ b/profiles/twelvestepintergroup/config/install/field.field.node.event.body.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.event
+  module:
+    - text
+_core:
+  default_config_hash: RlC4-RyenYNJRqYvpnxgtzSH4_l5OhvioeRom66_c7w
+id: node.event.body
+field_name: body
+entity_type: node
+bundle: event
+label: Description
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+field_type: text_with_summary

--- a/profiles/twelvestepintergroup/config/install/field.field.node.event.field_address.yml
+++ b/profiles/twelvestepintergroup/config/install/field.field.node.event.field_address.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_address
+    - node.type.event
+  module:
+    - address
+_core:
+  default_config_hash: a-Af-5agHDwT4POkt1lmDTtUpMSujSFcvx6ddWAv9rM
+id: node.event.field_address
+field_name: field_address
+entity_type: node
+bundle: event
+label: Address
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  available_countries: {  }
+  fields:
+    administrativeArea: administrativeArea
+    locality: locality
+    dependentLocality: dependentLocality
+    postalCode: postalCode
+    sortingCode: sortingCode
+    addressLine1: addressLine1
+    addressLine2: addressLine2
+    organization: organization
+    recipient: '0'
+  langcode_override: ''
+field_type: address

--- a/profiles/twelvestepintergroup/config/install/field.field.node.event.field_end_date.yml
+++ b/profiles/twelvestepintergroup/config/install/field.field.node.event.field_end_date.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_end_date
+    - node.type.event
+  module:
+    - datetime
+_core:
+  default_config_hash: aOOGyhUHXy1D0ySriOdY7RFJnT9N35kjuhVTS6sTbx8
+id: node.event.field_end_date
+field_name: field_end_date
+entity_type: node
+bundle: event
+label: 'End date'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/profiles/twelvestepintergroup/config/install/field.field.node.event.field_group.yml
+++ b/profiles/twelvestepintergroup/config/install/field.field.node.event.field_group.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_group
+    - node.type.event
+_core:
+  default_config_hash: K8esSV3UL6JIUfJtTEt1-kcB1mTM4nYzg22qYz5EKKw
+id: node.event.field_group
+field_name: field_group
+entity_type: node
+bundle: event
+label: Group
+description: 'Optional sponsoring group'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:twelvestepgroup'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: _none
+    auto_create: false
+field_type: entity_reference

--- a/profiles/twelvestepintergroup/config/install/field.field.node.event.field_start_date.yml
+++ b/profiles/twelvestepintergroup/config/install/field.field.node.event.field_start_date.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_start_date
+    - node.type.event
+  module:
+    - datetime
+_core:
+  default_config_hash: LuwLUaPd6mokdaKKBiB5F7jnXRjeLDX2S04atyVzIS8
+id: node.event.field_start_date
+field_name: field_start_date
+entity_type: node
+bundle: event
+label: 'Start date'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/profiles/twelvestepintergroup/config/install/field.storage.node.field_address.yml
+++ b/profiles/twelvestepintergroup/config/install/field.storage.node.field_address.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - address
+    - node
+id: node.field_address
+field_name: field_address
+entity_type: node
+type: address
+settings: {  }
+module: address
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/profiles/twelvestepintergroup/config/install/field.storage.node.field_end_date.yml
+++ b/profiles/twelvestepintergroup/config/install/field.storage.node.field_end_date.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_end_date
+field_name: field_end_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/profiles/twelvestepintergroup/config/install/field.storage.node.field_group.yml
+++ b/profiles/twelvestepintergroup/config/install/field.storage.node.field_group.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - twelvestepmodule
+id: node.field_group
+field_name: field_group
+entity_type: node
+type: entity_reference
+settings:
+  target_type: twelvestepgroup
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/profiles/twelvestepintergroup/config/install/field.storage.node.field_start_date.yml
+++ b/profiles/twelvestepintergroup/config/install/field.storage.node.field_start_date.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_start_date
+field_name: field_start_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/profiles/twelvestepintergroup/config/install/node.type.event.yml
+++ b/profiles/twelvestepintergroup/config/install/node.type.event.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+_core:
+  default_config_hash: IjdZONC2JqPKAWwrbcPFOPcNHS_2N-lHWNNn-olPXuc
+name: Event
+type: event
+description: 'Use events to list special events, such as Birthday celebrations, Holiday parties, and Committee meetings. Do not list meetings here.'
+help: ''
+new_revision: false
+preview_mode: 2
+display_submitted: false

--- a/profiles/twelvestepintergroup/config/install/views.view.events.yml
+++ b/profiles/twelvestepintergroup/config/install/views.view.events.yml
@@ -1,0 +1,236 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.event
+  module:
+    - datetime
+    - node
+    - user
+_core:
+  default_config_hash: qLErq-ZEF-VZxxlqa6hZqxyFfFbR7WMDXvjipkvuqZE
+id: events
+label: Events
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 3
+          offset: 0
+      style:
+        type: default
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: teaser
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        status:
+          value: true
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            event: event
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        field_start_date_value:
+          id: field_start_date_value
+          table: node__field_start_date
+          field: field_start_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: '-3 days'
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      sorts:
+        field_start_date_value:
+          id: field_start_date_value
+          table: node__field_start_date
+          field: field_start_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          granularity: minute
+          plugin_id: datetime
+      title: Events
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      use_more: true
+      use_more_always: false
+      use_more_text: more
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: Block
+    position: 2
+    display_options:
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: events
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/profiles/twelvestepintergroup/config/install/views.view.events.yml
+++ b/profiles/twelvestepintergroup/config/install/views.view.events.yml
@@ -11,7 +11,7 @@ dependencies:
 _core:
   default_config_hash: qLErq-ZEF-VZxxlqa6hZqxyFfFbR7WMDXvjipkvuqZE
 id: events
-label: Events
+label: Special Events
 module: views
 description: ''
 tag: ''
@@ -185,7 +185,7 @@ display:
             label: ''
           granularity: minute
           plugin_id: datetime
-      title: Events
+      title: Special Events
       header: {  }
       footer: {  }
       empty: {  }

--- a/profiles/twelvestepintergroup/twelvestepintergroup.install
+++ b/profiles/twelvestepintergroup/twelvestepintergroup.install
@@ -7,6 +7,7 @@
 use Drupal\user\Entity\User;
 use Drupal\user\RoleInterface;
 use Drupal\shortcut\Entity\Shortcut;
+use Drupal\block\Entity\Block;
 
 /**
  * Implements hook_install().

--- a/themes/twelvesteporgtheme/css/style.css
+++ b/themes/twelvesteporgtheme/css/style.css
@@ -2,9 +2,22 @@
  * Place your custom styles here.
  */
 
+#block-events, #block-aboutthissite {
+  background-color: #f5f5f5;
+  border: 1px solid black;
+  padding: 10px;
+  margin-bottom: 10px;
+}
+
+#block-events h2 {
+  font-size: 18px;
+  margin-top: initial;
+}
+
 @media only screen and (max-width: 768px) {
 
   #block-aboutthissite,
+  #block-events,
   .path-frontpage .navbar-text,
   .path-frontpage .page-header {
     display: none;


### PR DESCRIPTION
This is a beginning of special events. One special event is added to the demo site and displayed at the top of the front page. However, how it is displayed is site specific. I need to add better group, meeting, and location pages, that also display the special events specific to the group.

![search_meetings___twelve_step_intergroup_example_site](https://cloud.githubusercontent.com/assets/16479808/17218476/e66e8178-54b5-11e6-962b-f7abef1743df.png)
